### PR TITLE
Include PlanPal information in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,8 @@
 
 ![Ui](docs/images/Ui.png)
 
-* This is **a sample project for Software Engineering (SE) students**.<br>
-  Example usages:
-  * as a starting point of a course project (as opposed to writing everything from scratch)
-  * as a case study
-* The project simulates an ongoing software project for a desktop application (called _AddressBook_) used for managing contact details.
-  * It is **written in OOP fashion**. It provides a **reasonably well-written** code base **bigger** (around 6 KLoC) than what students usually write in beginner-level SE modules, without being overwhelmingly big.
-  * It comes with a **reasonable level of user and developer documentation**.
-* It is named `AddressBook Level 3` (`AB3` for short) because it was initially created as a part of a series of `AddressBook` projects (`Level 1`, `Level 2`, `Level 3` ...).
-* For the detailed documentation of this project, see the **[Address Book Product Website](https://se-education.org/addressbook-level3)**.
-* This project is a **part of the se-education.org** initiative. If you would like to contribute code to this project, see [se-education.org](https://se-education.org/#contributing-to-se-edu) for more info.
+* PlanPal is an **address book** designed for **student event planners** at NUS who need to manage contacts
+  (e.g., attendees, vendors, sponsors, and volunteers) for their events.
+* PlanPal offers a **centralized platform** to organize, track, and access contact information, ensuring 
+  efficient coordination and smooth communication throughout the event planning process.
+* This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: AddressBook Level-3
+title: PlanPal
 ---
 
 [![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,12 @@ title: AddressBook Level-3
 
 ![Ui](images/Ui.png)
 
-**AddressBook is a desktop application for managing your contact details.** While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
+* **PlanPal** is an address book designed for student event planners at NUS who need to manage contacts (e.g., attendees, vendors, sponsors, and volunteers) for their events. 
+* PlanPal offers a centralized platform to organize, track, and access contact information, ensuring efficient coordination and smooth communication throughout the event planning process.
+* While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
 
 * If you are interested in using AddressBook, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
 * If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
-
 
 **Acknowledgements**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ title: PlanPal
 * PlanPal offers a centralized platform to organize, track, and access contact information, ensuring efficient coordination and smooth communication throughout the event planning process.
 * While it has a GUI, most of the user interactions happen using a CLI (Command Line Interface).
 
-* If you are interested in using AddressBook, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
-* If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
+* If you are interested in using PlanPal, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
+* If you are interested about developing PlanPal, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 **Acknowledgements**
 * This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,5 +16,5 @@ title: PlanPal
 * If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
 **Acknowledgements**
-
+* This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).
 * Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5)


### PR DESCRIPTION
## Summary

This PR addresses issue #31 by removing the dummy placeholder information from the "About Us" section, and preparing it to reflect the actual context of the project.

## Changes
- Removed dummy text from the AboutUs component.
- Updated the AboutUs section to better reflect the project description and user profile.