### PR TITLE
Role tag

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -64,4 +64,8 @@ public class Name {
         return fullName.hashCode();
     }
 
+    @Override
+    public int compareTo(Name other) {
+        return this.fullName.compareTo(other.fullName);
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -14,7 +14,7 @@ import seedu.address.model.tag.Tag;
  * Represents a Person in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Person {
+public class Person implements Comparable<Person> {
 
     // Identity fields
     private final Name name;
@@ -114,4 +114,9 @@ public class Person {
                 .toString();
     }
 
+
+    @Override
+    public int compareTo(Person other) {
+        return this.getName().compareTo(other.getName());
+    }
 }

--- a/src/main/java/seedu/address/model/role/Attendee.java
+++ b/src/main/java/seedu/address/model/role/Attendee.java
@@ -5,7 +5,6 @@ package seedu.address.model.role;
  *
  */
 public class Attendee extends Role {
-    public static final String MESSAGE_CONSTRAINTS = "Attendees should be alphanumeric";
 
     public static final String ROLE_WORD = "attendee";
     public Attendee() {

--- a/src/main/java/seedu/address/model/role/Attendee.java
+++ b/src/main/java/seedu/address/model/role/Attendee.java
@@ -1,0 +1,14 @@
+package seedu.address.model.role;
+
+/**
+ * Represents an Attendee in the event.
+ *
+ */
+public class Attendee extends Role {
+    public static final String MESSAGE_CONSTRAINTS = "Attendees should be alphanumeric";
+
+    public static final String ROLE_WORD = "attendee";
+    public Attendee() {
+        super("attendee");
+    }
+}

--- a/src/main/java/seedu/address/model/role/Attendee.java
+++ b/src/main/java/seedu/address/model/role/Attendee.java
@@ -8,6 +8,6 @@ public class Attendee extends Role {
 
     public static final String ROLE_WORD = "attendee";
     public Attendee() {
-        super("attendee");
+        super(Attendee.ROLE_WORD);
     }
 }

--- a/src/main/java/seedu/address/model/role/Role.java
+++ b/src/main/java/seedu/address/model/role/Role.java
@@ -1,0 +1,110 @@
+package seedu.address.model.role;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.model.person.Person;
+
+
+/**
+ * Represents a Role in the address book.
+ */
+public abstract class Role {
+    public static final String MESSAGE_CONSTRAINTS = "Roles should be alphanumeric";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+
+    private final HashSet<Person> personList = new HashSet<>();
+
+
+    private final String roleName;
+
+    /**
+     * Constructs a {@code Role}.
+     *
+     * @param roleName A valid role name.
+     */
+    protected Role(String roleName) {
+        requireNonNull(roleName);
+        checkArgument(isValidRoleName(roleName), MESSAGE_CONSTRAINTS);
+        this.roleName = roleName;
+    }
+
+
+
+    /**
+     * Returns true if a given string is a valid role name.
+     */
+    public static boolean isValidRoleName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Role)) {
+            return false;
+        }
+
+        Role otherRole = (Role) other;
+        return roleName.equals(otherRole.roleName);
+    }
+
+    @Override
+    public int hashCode() {
+        return roleName.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '[' + roleName + ']';
+    }
+
+    /**
+     * Gets the people tagged under role as a string
+     * @return String representation of all people tagged under a role
+     */
+    public String getPeopleString() {
+        List<Person> people = new ArrayList<>(personList);
+        Collections.sort(people);
+        return people.toString();
+    }
+
+    /**
+     * Adds a person to the role
+     * @param person the person to be added
+     */
+    public void addPerson(Person person) {
+        this.personList.add(person);
+    }
+
+    /**
+     * Removes a person from the role
+     * @param person the person to be removed
+     */
+    public void removePerson(Person person) {
+        this.personList.remove(person);
+    }
+    /**
+     * Returns the people tagged under the role
+     * @return Set of people tagged under the role
+     */
+    public Set<Person> getPeople() {
+        return this.personList;
+    }
+
+    public boolean isRole(Person person) {
+        return this.personList.contains(person);
+    }
+}

--- a/src/main/java/seedu/address/model/role/Role.java
+++ b/src/main/java/seedu/address/model/role/Role.java
@@ -94,7 +94,13 @@ public abstract class Role {
      * @param person the person to be removed
      */
     public void removePerson(Person person) {
+        if (!this.personList.contains(person)) {
+            throw new IllegalArgumentException("Person not found in role");
+        }
         this.personList.remove(person);
+        //TODO: maybe exception if not found? unsure currently
+        // originally tagged
+
     }
     /**
      * Returns the people tagged under the role
@@ -104,7 +110,7 @@ public abstract class Role {
         return this.personList;
     }
 
-    public boolean isRole(Person person) {
+    public boolean isTagged(Person person) {
         return this.personList.contains(person);
     }
 }

--- a/src/main/java/seedu/address/model/role/Role.java
+++ b/src/main/java/seedu/address/model/role/Role.java
@@ -72,7 +72,7 @@ public abstract class Role {
     }
 
     /**
-     * Gets the people tagged under role as a string
+     * Gets the people tagged under role as a string. Should be displayed as [ person1, person2, ... ]
      * @return String representation of all people tagged under a role
      */
     public String getPeopleString() {

--- a/src/main/java/seedu/address/model/role/RoleHandler.java
+++ b/src/main/java/seedu/address/model/role/RoleHandler.java
@@ -32,7 +32,7 @@ public class RoleHandler {
      * @param role String representation of role.
      * @return Corresponding role object.
      */
-    public Role getRole(String role) {
+    public Role getRole(String role) throws InvalidRoleException {
         role = role.trim().toLowerCase();
         switch (role) {
         case Attendee.ROLE_WORD:
@@ -45,7 +45,7 @@ public class RoleHandler {
             return VOLUNTEER;
         default:
 
-            return null;
+           throw new InvalidRoleException();
         }
     }
 

--- a/src/main/java/seedu/address/model/role/RoleHandler.java
+++ b/src/main/java/seedu/address/model/role/RoleHandler.java
@@ -63,6 +63,6 @@ public class RoleHandler {
         if (role == null) {
             throw new InvalidRoleException();
         }
-        return role.isRole(person);
+        return role.isTagged(person);
     }
 }

--- a/src/main/java/seedu/address/model/role/RoleHandler.java
+++ b/src/main/java/seedu/address/model/role/RoleHandler.java
@@ -57,9 +57,8 @@ public class RoleHandler {
         Objects.requireNonNull(roleString);
 
         Role role = getRole(roleString);
-        if (role == null) {
-            throw new InvalidRoleException();
-        }
+        //if role is invalid getRole should already throw an exception
+        assert role != null;
         return role.isTagged(person);
     }
 

--- a/src/main/java/seedu/address/model/role/RoleHandler.java
+++ b/src/main/java/seedu/address/model/role/RoleHandler.java
@@ -58,7 +58,6 @@ public class RoleHandler {
 
         Role role = getRole(roleString);
         //if role is invalid getRole should already throw an exception
-        assert role != null;
         return role.isTagged(person);
     }
 

--- a/src/main/java/seedu/address/model/role/RoleHandler.java
+++ b/src/main/java/seedu/address/model/role/RoleHandler.java
@@ -11,12 +11,9 @@ import seedu.address.model.role.exceptions.InvalidRoleException;
 public class RoleHandler {
     public static final String MESSAGE_CONSTRAINTS = "Roles should be alphanumeric";
 
-    /**
-     * Enum for the different types of roles
-     */
-    public enum RoleType {
-        SPONSOR, VOLUNTEER, ATTENDEE, VENDOR
-    }
+
+
+
     private static final Attendee ATTENDEE = new Attendee();
     private static final Sponsor SPONSOR = new Sponsor();
     private static final Vendor VENDOR = new Vendor();
@@ -65,4 +62,5 @@ public class RoleHandler {
         }
         return role.isTagged(person);
     }
+
 }

--- a/src/main/java/seedu/address/model/role/RoleHandler.java
+++ b/src/main/java/seedu/address/model/role/RoleHandler.java
@@ -1,0 +1,69 @@
+package seedu.address.model.role;
+
+import java.util.Objects;
+
+import seedu.address.model.person.Person;
+import seedu.address.model.role.exceptions.InvalidRoleException;
+
+/**
+ * Handles the checking of roles and adding to roles
+ */
+public class RoleHandler {
+    public static final String MESSAGE_CONSTRAINTS = "Roles should be alphanumeric";
+
+    /**
+     * Enum for the different types of roles
+     */
+    public enum RoleType {
+        SPONSOR, VOLUNTEER, ATTENDEE, VENDOR
+    }
+    private static final Attendee ATTENDEE = new Attendee();
+    private static final Sponsor SPONSOR = new Sponsor();
+    private static final Vendor VENDOR = new Vendor();
+    private static final Volunteer VOLUNTEER = new Volunteer();
+
+
+    public RoleHandler() {
+
+    }
+
+    /**
+     * Returns the specified role from string, null if invalid.
+     * @param role String representation of role.
+     * @return Corresponding role object.
+     */
+    public Role getRole(String role) {
+        role = role.trim().toLowerCase();
+        switch (role) {
+        case Attendee.ROLE_WORD:
+            return ATTENDEE;
+        case Sponsor.ROLE_WORD:
+            return SPONSOR;
+        case Vendor.ROLE_WORD:
+            return VENDOR;
+        case Volunteer.ROLE_WORD:
+            return VOLUNTEER;
+        default:
+
+            return null;
+        }
+    }
+
+    /**
+     * Checks if a person has the specified role
+     * @param person Person to check
+     * @param roleString String representation of a valid role
+     * @return True if person has the role, false otherwise
+     * @throws InvalidRoleException If roleString is invalid
+     */
+    public boolean isRole(Person person, String roleString) throws InvalidRoleException {
+        Objects.requireNonNull(person);
+        Objects.requireNonNull(roleString);
+
+        Role role = getRole(roleString);
+        if (role == null) {
+            throw new InvalidRoleException();
+        }
+        return role.isRole(person);
+    }
+}

--- a/src/main/java/seedu/address/model/role/RoleHandler.java
+++ b/src/main/java/seedu/address/model/role/RoleHandler.java
@@ -44,8 +44,7 @@ public class RoleHandler {
         case Volunteer.ROLE_WORD:
             return VOLUNTEER;
         default:
-
-           throw new InvalidRoleException();
+            throw new InvalidRoleException();
         }
     }
 

--- a/src/main/java/seedu/address/model/role/Sponsor.java
+++ b/src/main/java/seedu/address/model/role/Sponsor.java
@@ -8,6 +8,6 @@ public class Sponsor extends Role {
     public static final String ROLE_WORD = "sponsor";
 
     public Sponsor() {
-        super("sponsor");
+        super(Sponsor.ROLE_WORD);
     }
 }

--- a/src/main/java/seedu/address/model/role/Sponsor.java
+++ b/src/main/java/seedu/address/model/role/Sponsor.java
@@ -1,0 +1,13 @@
+package seedu.address.model.role;
+
+/**
+ * Represents a Sponsor in the event.
+ */
+public class Sponsor extends Role {
+
+    public static final String ROLE_WORD = "sponsor";
+
+    public Sponsor() {
+        super("sponsor");
+    }
+}

--- a/src/main/java/seedu/address/model/role/Vendor.java
+++ b/src/main/java/seedu/address/model/role/Vendor.java
@@ -1,0 +1,16 @@
+package seedu.address.model.role;
+
+/**
+ * Represents a Vendor in the event.
+ */
+public class Vendor extends Role {
+    public static final String MESSAGE_CONSTRAINTS = "Vendors should be alphanumeric";
+
+    public static final String ROLE_WORD = "vendor";
+
+    public Vendor() {
+        super("vendor");
+    }
+
+
+}

--- a/src/main/java/seedu/address/model/role/Vendor.java
+++ b/src/main/java/seedu/address/model/role/Vendor.java
@@ -8,7 +8,7 @@ public class Vendor extends Role {
     public static final String ROLE_WORD = "vendor";
 
     public Vendor() {
-        super("vendor");
+        super(Vendor.ROLE_WORD);
     }
 
 

--- a/src/main/java/seedu/address/model/role/Vendor.java
+++ b/src/main/java/seedu/address/model/role/Vendor.java
@@ -4,7 +4,6 @@ package seedu.address.model.role;
  * Represents a Vendor in the event.
  */
 public class Vendor extends Role {
-    public static final String MESSAGE_CONSTRAINTS = "Vendors should be alphanumeric";
 
     public static final String ROLE_WORD = "vendor";
 

--- a/src/main/java/seedu/address/model/role/Volunteer.java
+++ b/src/main/java/seedu/address/model/role/Volunteer.java
@@ -1,0 +1,13 @@
+package seedu.address.model.role;
+
+/**
+ * Represents a Volunteer in the event.
+ */
+public class Volunteer extends Role {
+    public static final String MESSAGE_CONSTRAINTS = "Volunteers should be alphanumeric";
+
+    public static final String ROLE_WORD = "volunteer";
+    public Volunteer() {
+        super("volunteer");
+    }
+}

--- a/src/main/java/seedu/address/model/role/Volunteer.java
+++ b/src/main/java/seedu/address/model/role/Volunteer.java
@@ -7,6 +7,6 @@ public class Volunteer extends Role {
 
     public static final String ROLE_WORD = "volunteer";
     public Volunteer() {
-        super("volunteer");
+        super(Volunteer.ROLE_WORD);
     }
 }

--- a/src/main/java/seedu/address/model/role/Volunteer.java
+++ b/src/main/java/seedu/address/model/role/Volunteer.java
@@ -4,7 +4,6 @@ package seedu.address.model.role;
  * Represents a Volunteer in the event.
  */
 public class Volunteer extends Role {
-    public static final String MESSAGE_CONSTRAINTS = "Volunteers should be alphanumeric";
 
     public static final String ROLE_WORD = "volunteer";
     public Volunteer() {

--- a/src/main/java/seedu/address/model/role/exceptions/InvalidRoleException.java
+++ b/src/main/java/seedu/address/model/role/exceptions/InvalidRoleException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.role.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified role.
+ */
+public class InvalidRoleException extends Exception {
+    public InvalidRoleException() {
+        super("Invalid Role input");
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -98,4 +98,9 @@ public class AddressBookParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
+
+    @Test
+    public void parseCommand_testCommand() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("editer /p 12345678"));
+    }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -57,4 +57,25 @@ public class NameTest {
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
     }
+
+    @Test
+    public void compareTo_lowerLexicographicalOrder() {
+        Name name1 = new Name("Alice");
+        Name name2 = new Name("Bob");
+        assertTrue(name1.compareTo(name2) < 0);
+    }
+
+    @Test
+    public void compareTo_higherLexicographicalOrder() {
+        Name name1 = new Name("Alice");
+        Name name2 = new Name("Bob");
+        assertTrue(name2.compareTo(name1) > 0);
+    }
+
+    @Test
+    public void compareTo_higherLexicographicalOrderSameLength() {
+        Name name1 = new Name("Alice");
+        Name name2 = new Name("Alicf");
+        assertTrue(name2.compareTo(name1) > 0);
+    }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -96,4 +96,18 @@ public class PersonTest {
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }
+
+    @Test
+    public void compareTo_lowerLexicographicalOrder() {
+        Person aliceCopy = new PersonBuilder(ALICE).build();
+        Person bobCopy = new PersonBuilder(BOB).build();
+        assertTrue(ALICE.compareTo(BOB) < 0);
+    }
+
+    @Test
+    public void compareTo_higherLexicographicalOrder() {
+        Person aliceCopy = new PersonBuilder(ALICE).build();
+        Person bobCopy = new PersonBuilder(BOB).build();
+        assertTrue(BOB.compareTo(ALICE) > 0);
+    }
 }

--- a/src/test/java/seedu/address/model/role/RoleHandlerTest.java
+++ b/src/test/java/seedu/address/model/role/RoleHandlerTest.java
@@ -1,0 +1,44 @@
+package seedu.address.model.role;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.role.exceptions.InvalidRoleException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RoleHandlerTest {
+    @Test
+    public void getRole_validRole_success() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            assert (roleHandler.getRole("attendee") instanceof Attendee);
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void getRole_invalidRole_success() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            assert (roleHandler.getRole("invalid") instanceof Vendor);
+
+        } catch (InvalidRoleException e) {
+            assert (true);
+        }
+    }
+
+    @Test
+    public void isRole_validRole_success() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            Role role1 = roleHandler.getRole("attendee");
+            Role role2 = roleHandler.getRole("attendee");
+            assertEquals(role1, role2);
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/model/role/RoleHandlerTest.java
+++ b/src/test/java/seedu/address/model/role/RoleHandlerTest.java
@@ -1,9 +1,11 @@
 package seedu.address.model.role;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.model.role.exceptions.InvalidRoleException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RoleHandlerTest {
     @Test

--- a/src/test/java/seedu/address/model/role/RoleHandlerTest.java
+++ b/src/test/java/seedu/address/model/role/RoleHandlerTest.java
@@ -124,4 +124,6 @@ public class RoleHandlerTest {
 
 
     }
+
+
 }

--- a/src/test/java/seedu/address/model/role/RoleHandlerTest.java
+++ b/src/test/java/seedu/address/model/role/RoleHandlerTest.java
@@ -1,6 +1,9 @@
 package seedu.address.model.role;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +22,38 @@ public class RoleHandlerTest {
         }
     }
 
+    @Test
+    public void getRole_vendor() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            assert (roleHandler.getRole("vendor") instanceof Vendor);
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void getRole_sponsor() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            assert (roleHandler.getRole("sponsor") instanceof Sponsor);
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void getRole_volunteer() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            assert (roleHandler.getRole("volunteer") instanceof Volunteer);
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
     @Test
     public void getRole_invalidRole_success() {
         RoleHandler roleHandler = new RoleHandler();
@@ -43,4 +78,50 @@ public class RoleHandlerTest {
         }
     }
 
+    @Test
+    public void isRole_hasRole_notInRole() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            Role role = roleHandler.getRole("attendee");
+            assert (!roleHandler.isRole(BOB, "attendee"));
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void isRole_hasRole_inRole() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            Role role = roleHandler.getRole("attendee");
+            role.addPerson(ALICE);
+            assert (roleHandler.isRole(ALICE, "attendee"));
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void isRole_hasDifferentRole_notInRole() {
+        RoleHandler roleHandler = new RoleHandler();
+        try {
+            Role role = roleHandler.getRole("attendee");
+            role.addPerson(ALICE);
+            assert (!roleHandler.isRole(ALICE, "sponsor"));
+
+        } catch (InvalidRoleException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void isRole_invalidRole_failure() {
+        RoleHandler roleHandler = new RoleHandler();
+
+        assertThrows(InvalidRoleException.class, () -> roleHandler.isRole(ALICE, "invalid"));
+
+
+    }
 }

--- a/src/test/java/seedu/address/model/role/RoleTest.java
+++ b/src/test/java/seedu/address/model/role/RoleTest.java
@@ -1,14 +1,12 @@
 package seedu.address.model.role;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+
 import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
-
-
 
 import seedu.address.model.person.Person;
 

--- a/src/test/java/seedu/address/model/role/RoleTest.java
+++ b/src/test/java/seedu/address/model/role/RoleTest.java
@@ -2,11 +2,13 @@ package seedu.address.model.role;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.ArrayList;
-import org.junit.jupiter.api.Test;
-
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+
 
 import seedu.address.model.person.Person;
 
@@ -60,27 +62,27 @@ public class RoleTest {
     }
 
     @Test
-    public void addPerson_ValidPerson_success() {
+    public void addPerson_personIsTagged() {
         Role role = new Attendee();
         role.addPerson(ALICE);
         assert role.isTagged(ALICE);
     }
 
     @Test
-    public void isTagged_ValidPerson_success() {
+    public void isTagged_personInRole() {
         Role role = new Attendee();
         role.addPerson(ALICE);
         assert role.isTagged(ALICE);
     }
 
     @Test
-    public void isTagged_ValidPerson_failure() {
+    public void isTagged_validPerson_failure() {
         Role role = new Attendee();
         assert !role.isTagged(ALICE);
     }
 
     @Test
-    public void removePerson_ValidPerson_success() {
+    public void removePerson_existingPerson() {
         Role role = new Attendee();
         role.addPerson(ALICE);
         role.removePerson(ALICE);
@@ -88,7 +90,7 @@ public class RoleTest {
     }
 
     @Test
-    public void removePerson_ValidPerson_notInRole() {
+    public void removePerson_personNotInRole() {
         Role role = new Attendee();
         assertThrows(IllegalArgumentException.class, () -> role.removePerson(ALICE));
     }

--- a/src/test/java/seedu/address/model/role/RoleTest.java
+++ b/src/test/java/seedu/address/model/role/RoleTest.java
@@ -1,0 +1,98 @@
+package seedu.address.model.role;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+
+import seedu.address.model.person.Person;
+
+
+
+
+
+
+
+public class RoleTest {
+
+
+    @Test
+    public void equals_equalRole() {
+        Role role1 = new Attendee();
+        Role role2 = new Attendee();
+        assertEquals(role1, role2);
+    }
+
+    @Test
+    public void equals_differentRole() {
+        Role role1 = new Attendee();
+        Role role2 = new Vendor();
+        assert (!role1.equals(role2));
+    }
+
+    @Test
+    public void equals_nullRole() {
+        Role role1 = new Attendee();
+        assert (!role1.equals(null));
+    }
+
+    @Test
+    public void equals_notRole() {
+        Role role1 = new Attendee();
+        assert (!role1.equals(new ArrayList<Person>()));
+    }
+
+    @Test
+    public void hashCode_sameRole() {
+        Role role1 = new Vendor();
+        Role role2 = new Vendor();
+        assertEquals(role1.hashCode(), role2.hashCode());
+    }
+
+    @Test
+    public void hashCode_differentRole() {
+        Role role1 = new Vendor();
+        Role role2 = new Sponsor();
+        assert (role1.hashCode() != role2.hashCode());
+    }
+
+    @Test
+    public void addPerson_ValidPerson_success() {
+        Role role = new Attendee();
+        role.addPerson(ALICE);
+        assert role.isTagged(ALICE);
+    }
+
+    @Test
+    public void isTagged_ValidPerson_success() {
+        Role role = new Attendee();
+        role.addPerson(ALICE);
+        assert role.isTagged(ALICE);
+    }
+
+    @Test
+    public void isTagged_ValidPerson_failure() {
+        Role role = new Attendee();
+        assert !role.isTagged(ALICE);
+    }
+
+    @Test
+    public void removePerson_ValidPerson_success() {
+        Role role = new Attendee();
+        role.addPerson(ALICE);
+        role.removePerson(ALICE);
+        assert !role.isTagged(ALICE);
+    }
+
+    @Test
+    public void removePerson_ValidPerson_notInRole() {
+        Role role = new Attendee();
+        assertThrows(IllegalArgumentException.class, () -> role.removePerson(ALICE));
+    }
+
+
+
+}

--- a/src/test/java/seedu/address/model/role/RoleTest.java
+++ b/src/test/java/seedu/address/model/role/RoleTest.java
@@ -3,8 +3,11 @@ package seedu.address.model.role;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +96,69 @@ public class RoleTest {
         assertThrows(IllegalArgumentException.class, () -> role.removePerson(ALICE));
     }
 
+    @Test
+    public void toString_attendee() {
+        Role role = new Attendee();
+        assertEquals(role.toString(), "[attendee]");
+    }
+
+
+    @Test
+    public void peopleString_noPeople() {
+        Role role = new Attendee();
+        assertEquals(role.getPeopleString(), "[]");
+    }
+
+    @Test
+    public void peopleString_onePerson() {
+        Role role = new Attendee();
+        role.addPerson(ALICE);
+        assertEquals(role.getPeopleString(), "[" + ALICE.toString() + "]");
+    }
+
+    @Test
+    public void peopleString_twoPerson() {
+        Role role = new Vendor();
+        role.addPerson(ALICE);
+        role.addPerson(BOB);
+        assertEquals(role.getPeopleString(), "[" + ALICE.toString() + ", " + BOB.toString() + "]");
+    }
+
+    @Test
+    public void peopleString_outputList() {
+        Role role = new Vendor();
+        role.addPerson(ALICE);
+        role.addPerson(BOB);
+        ArrayList<Person> people = new ArrayList<>();
+        people.add(ALICE);
+        people.add(BOB);
+        assertEquals(role.getPeopleString(), people.toString());
+    }
+    @Test
+    public void getPeople_noPeople() {
+        Role role = new Attendee();
+        assertEquals(role.getPeople().size(), 0);
+    }
+
+    @Test
+    public void getPeople_onePerson() {
+        Role role = new Attendee();
+        role.addPerson(ALICE);
+        Set<Person> people = new HashSet<Person>();
+        people.add(ALICE);
+        assertEquals(role.getPeople(), people);
+    }
+
+    @Test
+    public void getPeople_twoPerson() {
+        Role role = new Vendor();
+        role.addPerson(ALICE);
+        role.addPerson(BOB);
+        Set<Person> people = new HashSet<Person>();
+        people.add(ALICE);
+        people.add(BOB);
+        assertEquals(role.getPeople(), people);
+    }
 
 
 }


### PR DESCRIPTION
For #53 
Basic Implementation of Role class with RoleHandler

RoleHandler to be used to manage the roles when operating the model

Changes to Existing Classes:
- Person now implements Comparable<Person>
- Name now implements Comparable<Name>

As Role objects keep track of tagged Persons using a Set, implementing Comparable allows for a sorted output when using toString (may be useful for storage)


 
Not implemented:
- Adding of roles field to Person
- Any Parsing of roles or role command 
- Any commands related to roles
- Changing of UI PersonCard/PersonCardList 
- Anything related to storage (JSONAdaptedPerson)
- ~~Any testcases for Roles or RoleHandler~~
- ~~Test cases for Name and Person compareTo~~


For storage of roles, current plan is to have roles stored under individual Person entry, upon retrieving from storage, as each person is instantiated, add to the respective roles using RoleHandler

During runtime, 2 way association between Role and Person using Set, during storage, roles for a person stored with person (Role objects not stored)

For search by role, retrieve the set of persons tagged under a role object and set the updateFilteredList predicate based on if person is contained by the set