### PR TITLE
Add TelegramUsername class and test file

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum}_]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -16,7 +16,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum}_]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -13,8 +13,8 @@ public class TelegramUsername {
                     + "and it should not be blank";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * The first character of the address must be an alphabet.
+     * "_____" or "12345" are invalid usernames.
      */
     public static final String VALIDATION_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{4,31}$";
 
@@ -32,7 +32,7 @@ public class TelegramUsername {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string is a valid telegram username.
      */
     public static boolean isValidUsername(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -61,6 +61,7 @@ public class TelegramUsername {
 
     @Override
     public int hashCode() {
-        return telegramUsername.hashCode();
+        return telegramUsername.hashCode(); // Might be future concern since Telegram Usernames are case insensitive
+        // not sure how hashCodes are computed based on strings, and what the use of these hashcodes are
     }
 }

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -1,0 +1,66 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's Telegram Username in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidUsername(String)}
+ */
+public class TelegramUsername {
+    public static final String MESSAGE_CONSTRAINTS =
+            "Telegram Usernames should only contain alphanumeric characters and underscores, between 5 to 32 characters"
+                    + "and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{4,31}$";
+
+    public final String telegramUsername;
+
+    /**
+     * Constructs a {@code TelegramUsername}.
+     *
+     * @param username A valid telegram username.
+     */
+    public TelegramUsername(String username) {
+        requireNonNull(username);
+        checkArgument(isValidUsername(username), MESSAGE_CONSTRAINTS);
+        telegramUsername = username;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidUsername(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return telegramUsername;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof seedu.address.model.person.TelegramUsername)) {
+            return false;
+        }
+
+        seedu.address.model.person.TelegramUsername otherUsername = (seedu.address.model.person.TelegramUsername) other;
+        return telegramUsername.equalsIgnoreCase(otherUsername.telegramUsername);
+    }
+
+    @Override
+    public int hashCode() {
+        return telegramUsername.hashCode();
+    }
+}

--- a/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
+++ b/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
@@ -22,7 +22,7 @@ public class TelegramUsernameTest {
     }
 
     @Test
-    public void isValidName() {
+    public void isValidUsername_correctlyVerifiesUsernames() {
         // null name
         assertThrows(NullPointerException.class, () -> new TelegramUsername(null));
 
@@ -44,7 +44,7 @@ public class TelegramUsernameTest {
     }
 
     @Test
-    public void equals() {
+    public void equals_correctlyChecksUsernameEquality() {
         TelegramUsername username = new TelegramUsername("Valid_Name");
 
         // same values -> returns true
@@ -64,5 +64,20 @@ public class TelegramUsernameTest {
 
         // different values -> returns false
         assertNotEquals(username, new TelegramUsername("Other_Valid_Name"));
+    }
+
+    @Test
+    public void toString_correctlyConvertsToString() {
+        TelegramUsername username = new TelegramUsername("Valid_Name");
+        assertEquals("Valid_Name", username.toString());
+    }
+
+    @Test
+    public void hashCode_correctlyConvertsForSameUsername() {
+        TelegramUsername username1 = new TelegramUsername("Valid_Name");
+        TelegramUsername username2 = new TelegramUsername("Valid_Name");
+        TelegramUsername username3 = new TelegramUsername("Diff_Name");
+        assertTrue(username1.hashCode() == username2.hashCode());
+        assertFalse(username2.hashCode() == username3.hashCode());
     }
 }

--- a/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
+++ b/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
@@ -1,0 +1,68 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TelegramUsernameTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new TelegramUsername(null));
+    }
+
+    @Test
+    public void constructor_invalidName_throwsIllegalArgumentException() {
+        String invalidName = "";
+        assertThrows(IllegalArgumentException.class, () -> new TelegramUsername(invalidName));
+    }
+
+    @Test
+    public void isValidName() {
+        // null name
+        assertThrows(NullPointerException.class, () -> new TelegramUsername(null));
+
+        // invalid name
+        assertFalse(TelegramUsername.isValidUsername("")); // empty string
+        assertFalse(TelegramUsername.isValidUsername("1234")); // < 5 characters
+        assertFalse(TelegramUsername.isValidUsername("123456789012345678901234567890123")); // > 32 characters
+        assertFalse(TelegramUsername.isValidUsername("_1234")); // cannot start with underscore
+        assertFalse(TelegramUsername.isValidUsername("9hello")); // cannot start with a number
+        assertFalse(TelegramUsername.isValidUsername("^^^^^^^")); // only non-alphanumeric characters
+        assertFalse(TelegramUsername.isValidUsername("peter*")); // contains non-alphanumeric characters
+
+        // valid name
+        assertTrue(TelegramUsername.isValidUsername("peterjack")); // alphabets only
+        assertTrue(TelegramUsername.isValidUsername("p12345")); // alphabets and numbers only
+        assertTrue(TelegramUsername.isValidUsername("peter_the_2nd")); // alphanumeric characters with underscores
+        assertTrue(TelegramUsername.isValidUsername("CapitalTan")); // with capital letters
+        assertTrue(TelegramUsername.isValidUsername("David_Roger_Jackson_Ray_Jr_2nd")); // long names
+    }
+
+    @Test
+    public void equals() {
+        TelegramUsername username = new TelegramUsername("Valid_Name");
+
+        // same values -> returns true
+        assertEquals(username, new TelegramUsername("Valid_Name"));
+
+        // same values but different casing -> returns true
+        assertEquals(username, new TelegramUsername("valid_NAME"));
+
+        // same object -> returns true
+        assertEquals(username, username);
+
+        // null -> returns false
+        assertNotEquals(null, username);
+
+        // different types -> returns false
+        assertFalse(username.equals(5.0f));
+
+        // different values -> returns false
+        assertNotEquals(username, new TelegramUsername("Other_Valid_Name"));
+    }
+}


### PR DESCRIPTION
Closes #55 

### Add `TelegramUsername` and `TelegramUsernameTest` class. Implementation is highly similar to `Name` class.

A telegram username is valid if:
- is between 5 and 32 characters
- Starts with an alphabet
- Only contains alphanumeric characters and underscore

A telegram username is equal if
- The strings are equal, ignoring case.

Concern:
- `.hashCode()` function generates hashcodes based on the string, and this is case sensitive. Hence, 2 telegram usernames which might be equal by the `.equal()` function might not give the same `.hashCode()`. 
- I didn't change this for now since I am not sure what `.hashCode()` is being used for and what a desired effect might be