### PR TITLE
Fix duplicate handling in Edit Person command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -82,12 +82,12 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        boolean hasEmailOrPhoneChanged
-                = !(personToEdit.isSamePhone(editedPerson) && personToEdit.isSameEmail(editedPerson));
-        boolean hasDuplicateExistingPhone
-                = model.hasPhone(editedPerson) && editedPerson.getPhone() != personToEdit.getPhone();
-        boolean hasDuplicateExistingEmail
-                = model.hasEmail(editedPerson) && editedPerson.getEmail() != personToEdit.getEmail();
+        boolean hasEmailOrPhoneChanged =
+                !(personToEdit.isSamePhone(editedPerson) && personToEdit.isSameEmail(editedPerson));
+        boolean hasDuplicateExistingPhone =
+                model.hasPhone(editedPerson) && editedPerson.getPhone() != personToEdit.getPhone();
+        boolean hasDuplicateExistingEmail =
+                model.hasEmail(editedPerson) && editedPerson.getEmail() != personToEdit.getEmail();
 
         if (hasEmailOrPhoneChanged && (hasDuplicateExistingPhone || hasDuplicateExistingEmail)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -82,16 +82,14 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
-        }
+        boolean hasEmailOrPhoneChanged
+                = !(personToEdit.isSamePhone(editedPerson) && personToEdit.isSameEmail(editedPerson));
+        boolean hasDuplicateExistingPhone
+                = model.hasPhone(editedPerson) && editedPerson.getPhone() != personToEdit.getPhone();
+        boolean hasDuplicateExistingEmail
+                = model.hasEmail(editedPerson) && editedPerson.getEmail() != personToEdit.getEmail();
 
-        if (!(personToEdit.isSamePhone(editedPerson) && personToEdit.isSameEmail(editedPerson)) &&
-                (
-                        (model.hasPhone(editedPerson) && editedPerson.getPhone() != personToEdit.getPhone())
-                        || (model.hasEmail(editedPerson) && editedPerson.getEmail() != personToEdit.getEmail())
-                )
-        ) {
+        if (hasEmailOrPhoneChanged && (hasDuplicateExistingPhone || hasDuplicateExistingEmail)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -86,6 +86,15 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        if (!(personToEdit.isSamePhone(editedPerson) && personToEdit.isSameEmail(editedPerson)) &&
+                (
+                        (model.hasPhone(editedPerson) && editedPerson.getPhone() != personToEdit.getPhone())
+                        || (model.hasEmail(editedPerson) && editedPerson.getEmail() != personToEdit.getEmail())
+                )
+        ) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -68,6 +68,22 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a person with the same phone number as {@code person} exists in the address book.
+     */
+    public boolean hasPhone(Person person) {
+        requireNonNull(person);
+        return persons.containsPhone(person);
+    }
+
+    /**
+     * Returns true if a person with the same email as {@code person} exists in the address book.
+     */
+    public boolean hasEmail(Person person) {
+        requireNonNull(person);
+        return persons.containsEmail(person);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -58,6 +58,16 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a person with the same phone number as {@code person} exists in the address book.
+     */
+    boolean hasPhone(Person person);
+
+    /**
+     * Returns true if a person with the same email as {@code person} exists in the address book.
+     */
+    boolean hasEmail(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -94,6 +94,18 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPhone(Person person) {
+        requireNonNull(person);
+        return addressBook.hasPhone(person);
+    }
+
+    @Override
+    public boolean hasEmail(Person person) {
+        requireNonNull(person);
+        return addressBook.hasEmail(person);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -83,6 +83,28 @@ public class Person implements Comparable<Person> {
     }
 
     /**
+     * Returns true if both persons have the same phone number.
+     */
+    public boolean isSamePhone(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null && otherPerson.getPhone().equals(getPhone());
+    }
+
+    /**
+     * Returns true if both persons have the same email.
+     */
+    public boolean isSameEmail(Person otherPerson) {
+        if (otherPerson == this) {
+            return true;
+        }
+
+        return otherPerson != null && otherPerson.getEmail().equals(getEmail());
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -37,6 +37,22 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if the list contains an person with an equivalent phone number as the given argument.
+     */
+    public boolean containsPhone(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSamePhone);
+    }
+
+    /**
+     * Returns true if the list contains an person with an equivalent email as the given argument.
+     */
+    public boolean containsEmail(Person toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameEmail);
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -139,6 +139,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasPhone(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasEmail(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
@@ -94,6 +95,7 @@ public class AddressBookTest {
     @Test
     public void hasPhone_personWithSamePhoneInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
+        addressBook.addPerson(BOB);
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
         assertTrue(addressBook.hasPhone(editedAlice));
     }
@@ -112,6 +114,7 @@ public class AddressBookTest {
     @Test
     public void hasEmail_personWithSameEmailInAddressBook_returnsTrue() {
         addressBook.addPerson(ALICE);
+        addressBook.addPerson(BOB);
         Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
         assertTrue(addressBook.hasEmail(editedAlice));
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -76,6 +78,42 @@ public class AddressBookTest {
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         assertTrue(addressBook.hasPerson(editedAlice));
+    }
+
+    @Test
+    public void hasPhone_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasPhone(null));
+    }
+
+    @Test
+    public void hasPhone_personInAddressBook_returnsTrue() {
+        addressBook.addPerson(ALICE);
+        assertTrue(addressBook.hasPhone(ALICE));
+    }
+
+    @Test
+    public void hasPhone_personWithSamePhoneInAddressBook_returnsTrue() {
+        addressBook.addPerson(ALICE);
+        Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
+        assertTrue(addressBook.hasPhone(editedAlice));
+    }
+
+    @Test
+    public void hasEmail_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasEmail(null));
+    }
+
+    @Test
+    public void hasEmail_personInAddressBook_returnsTrue() {
+        addressBook.addPerson(ALICE);
+        assertTrue(addressBook.hasEmail(ALICE));
+    }
+
+    @Test
+    public void hasEmail_personWithSameEmailInAddressBook_returnsTrue() {
+        addressBook.addPerson(ALICE);
+        Person editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
+        assertTrue(addressBook.hasEmail(editedAlice));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -89,6 +89,38 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasPhone_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasPhone(null));
+    }
+
+    @Test
+    public void hasPhone_personNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasPhone(ALICE));
+    }
+
+    @Test
+    public void hasPhone_personInAddressBook_returnsTrue() {
+        modelManager.addPerson(ALICE);
+        assertTrue(modelManager.hasPhone(ALICE));
+    }
+
+    @Test
+    public void hasEmail_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasEmail(null));
+    }
+
+    @Test
+    public void hasEmail_personNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasPhone(ALICE));
+    }
+
+    @Test
+    public void hasEmail_personInAddressBook_returnsTrue() {
+        modelManager.addPerson(ALICE);
+        assertTrue(modelManager.hasEmail(ALICE));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
     }


### PR DESCRIPTION
## Overview

Duplicate handling has only been implemented for the "Add Person" function, but not the "Edit Person function"

As such, it is possible to edit a person to have the same email and/or phone number as another person. If duplicates are left to exist, the app will crash on next launch.

## Issues fixed
Fixes #72

This prevents the creation of multiple records of same phone number or email in the database.