### PR TITLE
Add colours to roles

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -42,11 +42,12 @@ public class Messages {
                 .append("; Email: ")
                 .append(person.getEmail())
                 .append("; Address: ")
-                .append(person.getAddress())
-                .append("; Tags: ");
+                .append(person.getAddress());
+
+        appendTelegramUsernameToMsg(person, builder);
         builder.append("; Roles: ");
         person.getRoles().forEach(builder::append);
-        appendTelegramUsernameToMsg(person, builder);
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -36,7 +36,7 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TELEGRAM + "johndoe "
 
-            + PREFIX_ROLE + "sponsor"
+            + PREFIX_ROLE + "sponsor "
 
             + PREFIX_ROLE + "attendee";
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -30,6 +30,8 @@ public class PersonCard extends UiPart<Region> {
 
     public final Person person;
 
+    private Map<String, String> roleColors = new HashMap<>();
+
     @FXML
     private HBox cardPane;
     @FXML
@@ -46,8 +48,6 @@ public class PersonCard extends UiPart<Region> {
     private Label telegramUsername;
     @FXML
     private FlowPane roles;
-
-    Map<String, String> roleColors = new HashMap<>();
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,6 +1,8 @@
 package seedu.address.ui;
 
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
@@ -8,6 +10,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
+import seedu.address.model.role.Role;
 
 
 /**
@@ -42,10 +45,9 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label telegramUsername;
     @FXML
-    private FlowPane tags;
-    @FXML
     private FlowPane roles;
 
+    Map<String, String> roleColors = new HashMap<>();
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -60,10 +62,33 @@ public class PersonCard extends UiPart<Region> {
         email.setText(person.getEmail().value);
         setTextForTelegramUsername(person);
 
-        person.getRoles().stream()
-                .sorted(Comparator.comparing(role -> role.getRoleName()))
-                .forEach(role -> roles.getChildren().add(new Label(role.getRoleName())));
+        roleColors.put("attendee", "#159b07");
+        roleColors.put("sponsor", "#12b6f3");
+        roleColors.put("vendor", "#f87f26");
+        roleColors.put("volunteer", "#d262f3");
 
+        person.getRoles().stream()
+                .sorted(Comparator.comparing(Role::getRoleName))
+                .forEach(this::addLabel);
+    }
+
+    /**
+     * Adds a label representing the specified role to the roles container.
+     *
+     * This method creates a new {@link Label} with the role name, sets the background color
+     * of the label based on the predefined mapping of role names to colors, and adds the label
+     * to the roles container.
+     *
+     * @param role The {@link Role} object whose name will be displayed in the label.
+     *             The color of the label is determined by the role's name.
+     * @throws NullPointerException if the role is null or if the role name is not found
+     *                              in the color mapping.
+     */
+    private void addLabel(Role role) {
+        Label roleLabel = new Label(role.getRoleName());
+        String color = roleColors.get(role.getRoleName());
+        roleLabel.setStyle("-fx-background-color: " + color + ";");
+        roles.getChildren().add(roleLabel);
     }
 
     private void setTextForTelegramUsername(Person person) {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -366,3 +366,4 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -30,12 +30,10 @@
           <Label fx:id="telegramUsername" styleClass="cell_small_label" />
         </HBox>
       </HBox>
-      <FlowPane fx:id="tags" />
       <FlowPane fx:id="roles" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <FlowPane fx:id ="roles" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -37,8 +37,6 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TELEGRAM_AMY = "amybee";
     public static final String VALID_TELEGRAM_BOB = "bobby";
-    public static final String VALID_TAG_HUSBAND = "husband";
-    public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_ROLE_ATTENDEE = "attendee";
     public static final String VALID_ROLE_SPONSOR = "sponsor";
     public static final String VALID_ROLE_VENDOR = "vendor";

--- a/src/test/java/seedu/address/storage/JsonAdaptedRoleTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedRoleTest.java
@@ -19,7 +19,6 @@ public class JsonAdaptedRoleTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
-    private static final String INVALID_TAG = "#friend";
     private static final String INVALID_TELE = "c";
     private static final String INVALID_ROLE = "invalidRole";
 


### PR DESCRIPTION
Roles are rendered with the same colour, which may be too boring.

This PR will allow rendering of different role labels with different colours to improve the GUI.

![image](https://github.com/user-attachments/assets/0779ff54-dda1-44f9-8405-8c52ff20702a)

Furthermore, some small bug fixes like correcting the addCommand instruction message and removing unused tag fields were made.