### PR TITLE
Telegram username dupe handling

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -26,7 +26,7 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TELEGRAM + "TELEGRAM_USERNAME] "
+            + "[" + PREFIX_TELEGRAM + "TELEGRAM_USERNAME]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -76,14 +76,13 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        boolean hasEmailOrPhoneChanged =
-                !(personToEdit.isSamePhone(editedPerson) && personToEdit.isSameEmail(editedPerson));
-        boolean hasDuplicateExistingPhone =
-                model.hasPhone(editedPerson) && editedPerson.getPhone() != personToEdit.getPhone();
-        boolean hasDuplicateExistingEmail =
-                model.hasEmail(editedPerson) && editedPerson.getEmail() != personToEdit.getEmail();
+        // It is not possible to have more than 1 duplicate in the model
+        if (model.countSamePersons(editedPerson) >= 2) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
 
-        if (hasEmailOrPhoneChanged && (hasDuplicateExistingPhone || hasDuplicateExistingEmail)) {
+        // It is possible to have 1, but that is only if that is the old version of you before editing
+        if (model.hasPerson(editedPerson) && !personToEdit.isSamePerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -60,6 +60,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// person-level operations
 
     /**
+     * Returns the number of persons in the address book with the same identity as {@code person}.
+     */
+    public int countSamePersons(Person person) {
+        requireNonNull(person);
+        return persons.countSamePerson(person);
+    }
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     public boolean hasPerson(Person person) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -53,6 +53,11 @@ public interface Model {
     ReadOnlyAddressBook getAddressBook();
 
     /**
+     * Returns the number of persons in the address book with the same identity as {@code person}.
+     */
+    int countSamePersons(Person person);
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -88,6 +88,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public int countSamePersons(Person person) {
+        requireNonNull(person);
+        return addressBook.countSamePersons(person);
+    }
+
+    @Override
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return addressBook.hasPerson(person);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -55,7 +55,8 @@ public class Person implements Comparable<Person> {
     }
 
     /**
-     * Returns true if both persons have the same phone number or email.
+     * Returns true if both persons have the same phone number or email or telegram handle.
+     * If either one or both has no telegram handle, then ignore telegram handle.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -63,9 +64,20 @@ public class Person implements Comparable<Person> {
             return true;
         }
 
-        return otherPerson != null
-                && (otherPerson.getPhone().equals(getPhone())
-                || otherPerson.getEmail().equals(getEmail()));
+        if (otherPerson == null) {
+            return false;
+        }
+
+        // If either party has no telegram username, then just check for uniqueness in phone and email
+        if (!getTelegramUsername().hasUsername() || !otherPerson.getTelegramUsername().hasUsername()) {
+            return otherPerson.getPhone().equals(getPhone())
+                    || otherPerson.getEmail().equals(getEmail());
+        }
+
+        // Otherwise, check that phone, email and telegram username are all unique
+        return otherPerson.getPhone().equals(getPhone())
+                || otherPerson.getEmail().equals(getEmail())
+                || otherPerson.getTelegramUsername().equals(getTelegramUsername());
     }
 
     /**
@@ -126,6 +138,7 @@ public class Person implements Comparable<Person> {
                 .add("phone", phone)
                 .add("email", email)
                 .add("address", address)
+                .add("telegram", telegramUsername)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -57,7 +57,7 @@ public class TelegramUsername {
 
         seedu.address.model.person.TelegramUsername otherUsername = (seedu.address.model.person.TelegramUsername) other;
         if (telegramUsername == null) {
-            return otherUsername.telegramUsername == null;
+            return otherUsername.telegramUsername == null;  // return True if both are null
         }
         return telegramUsername.equalsIgnoreCase(otherUsername.telegramUsername);
     }

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -15,7 +15,7 @@ public class TelegramUsername {
      * The first character of the address must be an alphabet.
      * "_____" or "12345" are invalid usernames.
      */
-    public static final String VALIDATION_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{4,31}$";
+    private static final String VALIDATION_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{4,31}$";
 
     // the only situation where the telegram username is null is when user did not input telegram tag
     public final String telegramUsername;
@@ -30,6 +30,15 @@ public class TelegramUsername {
             checkArgument(isValidUsername(username), MESSAGE_CONSTRAINTS);
         }
         telegramUsername = username;
+    }
+
+    /**
+     * Checks whether there is a telegram username.
+     *
+     * @return {@code true} if there is a telegram username, {@code false} if empty.
+     */
+    public boolean hasUsername() {
+        return telegramUsername != null;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -66,7 +66,7 @@ public class TelegramUsername {
 
         seedu.address.model.person.TelegramUsername otherUsername = (seedu.address.model.person.TelegramUsername) other;
         if (telegramUsername == null) {
-            return otherUsername.telegramUsername == null;  // return True if both are null
+            return otherUsername.telegramUsername == null; // return True if both are null
         }
         return telegramUsername.equalsIgnoreCase(otherUsername.telegramUsername);
     }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -37,6 +37,14 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns the number of same persons as the given argument.
+     */
+    public int countSamePerson(Person toCheck) {
+        requireNonNull(toCheck);
+        return (int) internalList.stream().filter(toCheck::isSamePerson).count();
+    }
+
+    /**
      * Returns true if the list contains an person with an equivalent phone number as the given argument.
      */
     public boolean containsPhone(Person toCheck) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -134,6 +134,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public int countSamePersons(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -107,6 +107,33 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_doubleDuplicatePersonUnfilteredList_failure() {
+        // Tests the case where I edit only 1 field that must be unique to be same as an existing entry.
+        // Which means the new edited entry will be same as both the old entry and some other entry.
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        // Same Phone
+        EditPersonDescriptor samePhoneDescriptor = new EditPersonDescriptorBuilder(secondPerson)
+                .withPhone(firstPerson.getPhone().value).build();
+        EditCommand editCommand1 = new EditCommand(INDEX_SECOND_PERSON, samePhoneDescriptor);
+        assertCommandFailure(editCommand1, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+
+        // Same Email
+        EditPersonDescriptor sameEmailDescriptor = new EditPersonDescriptorBuilder(secondPerson)
+                .withEmail(firstPerson.getEmail().value).build();
+        EditCommand editCommand2 = new EditCommand(INDEX_SECOND_PERSON, sameEmailDescriptor);
+        assertCommandFailure(editCommand2, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+
+        // Same Telegram Username
+        EditPersonDescriptor sameTelegramUsernameDescriptor = new EditPersonDescriptorBuilder(secondPerson)
+                .withTelegramUsername(firstPerson.getTelegramUsername().telegramUsername).build();
+        EditCommand editCommand3 = new EditCommand(INDEX_SECOND_PERSON, sameTelegramUsernameDescriptor);
+        assertCommandFailure(editCommand3, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
     public void execute_duplicatePersonFilteredList_failure() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TELEGRAM_BOB;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
@@ -25,7 +26,7 @@ public class PersonTest {
 
         // same name, all other attributes different -> returns false
         Person editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withAddress(VALID_ADDRESS_BOB).build();
+                .withAddress(VALID_ADDRESS_BOB).withTelegramUsername(VALID_TELEGRAM_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns true

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -41,6 +41,37 @@ public class PersonTest {
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
         assertTrue(BOB.isSamePerson(editedBob));
+
+        // same phone, all other attributes different -> returns true
+        Person editedAlice2 = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withTelegramUsername(VALID_TELEGRAM_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice2));
+
+        // same email, all other attributes different -> return true
+        Person editedAlice3 = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB)
+                .withAddress(VALID_ADDRESS_BOB).withTelegramUsername(VALID_TELEGRAM_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice3));
+
+        // same telegram username, all other attributes different -> return true
+        Person editedAlice4 = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB).build();
+        assertTrue(ALICE.isSamePerson(editedAlice4));
+
+        // telegram username differs in case, all other attributes different -> return true
+        Person editedAlice5 = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTelegramUsername(ALICE.getTelegramUsername().toString().toUpperCase()).build();
+        assertTrue(ALICE.isSamePerson(editedAlice5));
+
+        // no telegram username, all attributes different -> return false
+        Person editedAlice6 = new PersonBuilder(ALICE).withTelegramUsername(null).build();
+        Person editedBob2 = new PersonBuilder(BOB).withTelegramUsername(null).build();
+        assertFalse(editedBob2.isSamePerson(editedAlice6));
+
+        // no telegram username, all attributes same -> return true
+        Person editedBob3 = new PersonBuilder(BOB).withTelegramUsername(null).build();
+        assertTrue(editedBob2.isSamePerson(editedBob3));
+
     }
 
     @Test
@@ -81,7 +112,8 @@ public class PersonTest {
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
+                + ", telegram=" + ALICE.getTelegramUsername() + "}";
         assertEquals(expected, ALICE.toString());
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -131,7 +131,7 @@ public class PersonTest {
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress()
-                + ", telegram=" + ALICE.getTelegramUsername() + "}";
+                + ", telegram=" + ALICE.getTelegramUsername()
                 + ", roles=" + ALICE.getRoles() + "}";
         assertEquals(expected, ALICE.toString());
     }

--- a/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
+++ b/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
@@ -58,6 +58,23 @@ public class TelegramUsernameTest {
     }
 
     @Test
+    public void equals_oneNullTelegramUsername_returnsFalse() {
+        TelegramUsername nullUsername = new TelegramUsername(null);
+        TelegramUsername validUsername = new TelegramUsername("valid_name");
+
+        assertFalse(validUsername.equals(nullUsername));
+        assertFalse(nullUsername.equals(validUsername));
+    }
+
+    @Test
+    public void equals_bothNullTelegramUsername_returnsTrue() {
+        TelegramUsername nullUsername1 = new TelegramUsername(null);
+        TelegramUsername nullUsername2 = new TelegramUsername(null);
+
+        assertEquals(nullUsername1, nullUsername2);
+    }
+
+    @Test
     public void toString_correctlyConvertsToString() {
         TelegramUsername username = new TelegramUsername("Valid_Name");
         assertEquals("Valid_Name", username.toString());

--- a/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
+++ b/src/test/java/seedu/address/model/person/TelegramUsernameTest.java
@@ -58,6 +58,14 @@ public class TelegramUsernameTest {
     }
 
     @Test
+    public void hasUsername_returnsAsExpected() {
+        TelegramUsername nullUsername = new TelegramUsername(null);
+        assertFalse(nullUsername.hasUsername());
+        TelegramUsername validUsername = new TelegramUsername("valid_name");
+        assertTrue(validUsername.hasUsername());
+    }
+
+    @Test
     public void equals_oneNullTelegramUsername_returnsFalse() {
         TelegramUsername nullUsername = new TelegramUsername(null);
         TelegramUsername validUsername = new TelegramUsername("valid_name");


### PR DESCRIPTION
Fix #79

## **Changelog**

### `TelegramUsername`
- Null Telegram Usernames are still equal to other Null Telegram Usernames. This might seem unintuitive:
    - 1.  Because `equals` recognise null usernames to be different could help us in implementing uniqueness in persons when they both have no telegram username. 
    - 2. And also because IRL, you can choose to have no telegram username, but still be a unique user on telegram
    - However, this caused issues in certain test cases which relied on equality checking to check whether the parser is adding the same person (without a telegram username) 
    - Additionally, a telegram username on it's own cannot enforce uniqueness, it's a weak notion of identity, so on it's own, even if it's null, it must still be tagged to a unique phone and email.

### `Person`
- Will check if both have telegram username, if either one of them don't, then they will only check for uniqueness in phone and email
- If both have telegram username, then they will check for uniqueness for all phone, email and telegram username.
- Note that the uniqueness is individual, not a tuple

### `EditCommand`
- I simplified some of the code
- There are mainly 2 cases to look out for:
    - 1. When NEW is different from OLD but same as some other person already in the model
    - 2. When NEW is same as OLD and also same as some other person already in the model
 - The old method before Brian updated fails on case b, because it assumes that IF there is a duplicate, and if NEW is same as OLD, then that must be the only duplicate, which is valid. However, there might be another entity in the model with the same phone / email or telegram username
 - To resolve this, I created a new function to count how many duplicates are there in the model
 - I then eliminate case b by adding an extra check to count dupes in the model, the `EditCommand` is immediately rejected if there are more than 1 duplicates.
 