### PR TITLE
Update edit telegram username

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -52,8 +52,9 @@ public class Messages {
     }
 
     private static void appendTelegramUsernameToMsg(Person person, StringBuilder builder) {
+        builder.append("; Telegram username: ");
         if (person.getTelegramUsername().toString() != null) {
-            builder.append("; Telegram username: ").append(person.getTelegramUsername());
+            builder.append(person.getTelegramUsername());
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -114,9 +114,6 @@ public class EditCommand extends Command {
         TelegramUsername updatedTeleUsername = editPersonDescriptor.getTelegramUsername()
                 .orElse(personToEdit.getTelegramUsername());
 
-        //Role[] updatedRoles = (editPersonDescriptor.getRoles().orElse(personToEdit.getRoles())).toArray(new Role[0]);
-
-
         Set<Role> updatedRoles = editPersonDescriptor.getRoles().orElse(personToEdit.getRoles());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -49,7 +49,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         TelegramUsername telegramUsername = ParserUtil
-                .parseTele(argMultimap.getValue(PREFIX_TELEGRAM).orElse(null)); // null to represent input absent
+                .parseTeleOnAdd(argMultimap.getValue(PREFIX_TELEGRAM).orElse(null)); // null to represent input absent
 
         //Set <Role> roleList = ParserUtil.parseRoles(argMultimap.getAllValues(PREFIX_ROLE));
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -39,7 +39,6 @@ public class EditCommandParser implements Parser<EditCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_TELEGRAM, PREFIX_ROLE);
 
-
         Index index;
 
         try {
@@ -66,10 +65,9 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         if (argMultimap.getValue(PREFIX_TELEGRAM).isPresent()) {
-            editPersonDescriptor.setTelegramUsername(ParserUtil.parseTele(argMultimap.getValue(PREFIX_TELEGRAM)
-                    .orElse(null)));
+            editPersonDescriptor.setTelegramUsername(ParserUtil.parseTeleOnEdit(argMultimap.getValue(PREFIX_TELEGRAM)
+                    .get()));
         }
-
 
         parseRolesForEdit(argMultimap.getAllValues(PREFIX_ROLE)).ifPresent(editPersonDescriptor::setRoles);
         if (!editPersonDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -84,7 +84,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses the given {@code String telegramUsername} and returns a {@code TelegramUsername} object.
+     * Parses the given {@code String telegramUsername} on add command and returns a {@code TelegramUsername} object.
      * Leading and trailing spaces will be trimmed.
      *
      * @param telegramUsername The username string to be parsed. Can be {@code null}.
@@ -92,9 +92,30 @@ public class ParserUtil {
      * @throws ParseException if the provided {@code telegramUsername} is invalid according to the
      *         {@code TelegramUsername#isValidUsername(String)} method.
      */
-    public static TelegramUsername parseTele(String telegramUsername) throws ParseException {
+    public static TelegramUsername parseTeleOnAdd(String telegramUsername) throws ParseException {
         if (telegramUsername == null) {
             return new TelegramUsername(telegramUsername);
+        }
+        String trimmedTelegramUsername = telegramUsername.trim();
+        if (!TelegramUsername.isValidUsername(trimmedTelegramUsername)) {
+            throw new ParseException(TelegramUsername.MESSAGE_CONSTRAINTS);
+        }
+        return new TelegramUsername(trimmedTelegramUsername);
+    }
+
+    /**
+     * Parses the given {@code String telegramUsername} on edit command and returns a {@code TelegramUsername} object.
+     * Leading and trailing spaces will be trimmed. Difference between this parse and the one for add command is that
+     * this parse method allows removal of telegram username when user input empty input.
+     *
+     * @param telegramUsername The username string to be parsed
+     * @return A {@code TelegramUsername} object with the trimmed username.
+     * @throws ParseException if the provided {@code telegramUsername} is invalid according to the
+     *         {@code TelegramUsername#isValidUsername(String)} method.
+     */
+    public static TelegramUsername parseTeleOnEdit(String telegramUsername) throws ParseException {
+        if (telegramUsername.isEmpty()) {
+            return new TelegramUsername(null);
         }
         String trimmedTelegramUsername = telegramUsername.trim();
         if (!TelegramUsername.isValidUsername(trimmedTelegramUsername)) {

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramUsername;
 import seedu.address.model.role.Role;
 import seedu.address.model.role.RoleHandler;
 
@@ -26,12 +27,14 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_TELE = "a";
     private static final String INVALID_ROLE = "owner";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_TELE = "rachel";
 
     private static final String VALID_ROLE_1 = "vendor";
     private static final String VALID_ROLE_2 = "sponsor";
@@ -148,6 +151,54 @@ public class ParserUtilTest {
         String emailWithWhitespace = WHITESPACE + VALID_EMAIL + WHITESPACE;
         Email expectedEmail = new Email(VALID_EMAIL);
         assertEquals(expectedEmail, ParserUtil.parseEmail(emailWithWhitespace));
+    }
+
+    @Test
+    public void parseTeleOnAdd_nullTelegramUsername() throws ParseException {
+        TelegramUsername expectedTelegramUsername = new TelegramUsername(null);
+        assertEquals(expectedTelegramUsername, ParserUtil.parseTeleOnAdd(null));
+    }
+
+    @Test
+    public void parseTeleOnAdd_invalidTelegramUsername_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTeleOnAdd(INVALID_TELE));
+    }
+
+    @Test
+    public void parseTeleOnAdd_validValueWithWhitespace_returnsTrimmedTele() throws ParseException {
+        String teleWithWhitespace = WHITESPACE + VALID_TELE + WHITESPACE;
+        TelegramUsername expectedTelegramUsername = new TelegramUsername(VALID_TELE);
+        assertEquals(expectedTelegramUsername, ParserUtil.parseTeleOnAdd(teleWithWhitespace));
+    }
+
+    @Test
+    public void parseTeleOnAdd_validValueWithoutWhitespace_returnsTele() throws Exception {
+        TelegramUsername expectedTelegramUsername = new TelegramUsername(VALID_TELE);
+        assertEquals(expectedTelegramUsername, ParserUtil.parseTeleOnAdd(VALID_TELE));
+    }
+
+    @Test
+    public void parseTeleOnEdit_emptyTelegramUsername_removesTele() throws ParseException {
+        TelegramUsername expectedTelegramUsername = new TelegramUsername(null);
+        assertEquals(expectedTelegramUsername, ParserUtil.parseTeleOnEdit(""));
+    }
+
+    @Test
+    public void parseTeleOnEdit_invalidTelegramUsername_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTeleOnEdit(INVALID_TELE));
+    }
+
+    @Test
+    public void parseTeleOnEdit_validValueWithWhitespace_returnsTrimmedTele() throws ParseException {
+        String teleWithWhitespace = WHITESPACE + VALID_TELE + WHITESPACE;
+        TelegramUsername expectedTelegramUsername = new TelegramUsername(VALID_TELE);
+        assertEquals(expectedTelegramUsername, ParserUtil.parseTeleOnEdit(teleWithWhitespace));
+    }
+
+    @Test
+    public void parseTeleOnEdit_validValueWithoutWhitespace_returnsTele() throws Exception {
+        TelegramUsername expectedTelegramUsername = new TelegramUsername(VALID_TELE);
+        assertEquals(expectedTelegramUsername, ParserUtil.parseTeleOnEdit(VALID_TELE));
     }
 
     @Test


### PR DESCRIPTION
Currently edit telegram username using t/ does not allow removal of telegram username as it will be marked as invalid input.

To keep in line with the ability to remove optional fields, adding the ability to remove telegram username on edit with empty t/ can be beneficial.

closes #92 