### PR TITLE
Init event manager class

### DIFF
--- a/src/main/java/seedu/address/model/event/EventList.java
+++ b/src/main/java/seedu/address/model/event/EventList.java
@@ -1,0 +1,119 @@
+package seedu.address.model.event;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.event.exceptions.EventNotFoundException;
+
+/**
+ * A list of events that does not allow nulls.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * Currently, this DOES NOT check for duplicates for simplicity.
+ */
+public class EventList implements Iterable<Event> {
+
+    private final ObservableList<Event> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Event> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent event as the given argument.
+     */
+    public boolean contains(Event toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::equals);
+    }
+
+    /**
+     * Adds an event to the list.
+     */
+    public void add(Event toAdd) {
+        requireNonNull(toAdd);
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the event {@code target} in the list with {@code editedEvent}.
+     * {@code target} must exist in the list.
+     * The event identity of {@code editedEvent} must not be the same as another existing event in the list.
+     */
+    public void setEvent(Event target, Event editedEvent) {
+        requireAllNonNull(target, editedEvent);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new EventNotFoundException();
+        }
+
+        internalList.set(index, editedEvent);
+    }
+
+    /**
+     * Removes the equivalent event from the list.
+     * The event must exist in the list.
+     */
+    public void remove(Event toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new EventNotFoundException();
+        }
+    }
+
+    public void setEvents(EventList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code events}.
+     * {@code events} must not contain duplicate events.
+     */
+    public void setEvents(List<Event> events) {
+        requireAllNonNull(events);
+        internalList.setAll(events);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Event> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Event> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EventList)) {
+            return false;
+        }
+
+        EventList otherEventList = (EventList) other;
+        return internalList.equals(otherEventList.internalList);
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return internalList.toString();
+    }
+}

--- a/src/main/java/seedu/address/model/event/EventManager.java
+++ b/src/main/java/seedu/address/model/event/EventManager.java
@@ -1,13 +1,6 @@
 package seedu.address.model.event;
 
-import java.util.List;
-import java.util.ArrayList;
-
 import javafx.collections.ObservableList;
-import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.event.exceptions.EventNotFoundException;
-import seedu.address.model.event.exceptions.EventException;
-import seedu.address.model.person.Person;
 
 /**
  * Wraps all {@code Event} and abstracts away
@@ -26,15 +19,33 @@ public class EventManager implements ReadOnlyEventManager {
     }
 
     // Minimal Functions needed to deal with Events
-    public void addEvent(Event e) {
-        this.eventList.add(e);
+
+    /**
+     * Adds an event into the event list.
+     *
+     * @param event A event to be added.
+     */
+    public void addEvent(Event event) {
+        this.eventList.add(event);
     }
 
-    public void removeEvent(Event e) {
+    /**
+     * Removes an event from the event list.
+     *
+     * @param event An event to be removed.
+     */
+    public void removeEvent(Event event) {
         // probably need to add a check here
-        this.eventList.remove(e);
+        this.eventList.remove(event);
     }
 
+    /**
+     * Replaces the given event {@code target} in the list with {@code editedEvent}.
+     * {@code target} must exist in the event list.
+     *
+     * @param target The event to be replaced.
+     * @param editedEvent The event that replaces the target.
+     */
     public void setEvent(Event target, Event editedEvent) {
         this.eventList.setEvent(target, editedEvent);
     }

--- a/src/main/java/seedu/address/model/event/EventManager.java
+++ b/src/main/java/seedu/address/model/event/EventManager.java
@@ -1,0 +1,46 @@
+package seedu.address.model.event;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.event.exceptions.EventNotFoundException;
+import seedu.address.model.event.exceptions.EventException;
+import seedu.address.model.person.Person;
+
+/**
+ * Wraps all {@code Event} and abstracts away
+ * the logic of dealing with a large number of
+ * {@code Event} instances.
+ */
+public class EventManager implements ReadOnlyEventManager {
+    // TODO: enforce uniqueness?
+    private final EventList eventList;
+
+    /**
+     * Initialises an empty EventManager.
+     */
+    public EventManager() {
+        eventList = new EventList();
+    }
+
+    // Minimal Functions needed to deal with Events
+    public void addEvent(Event e) {
+        this.eventList.add(e);
+    }
+
+    public void removeEvent(Event e) {
+        // probably need to add a check here
+        this.eventList.remove(e);
+    }
+
+    public void setEvent(Event target, Event editedEvent) {
+        this.eventList.setEvent(target, editedEvent);
+    }
+
+    @Override
+    public ObservableList<Event> getEventList() {
+        return eventList.asUnmodifiableObservableList();
+    }
+}

--- a/src/main/java/seedu/address/model/event/ReadOnlyEventManager.java
+++ b/src/main/java/seedu/address/model/event/ReadOnlyEventManager.java
@@ -2,6 +2,9 @@ package seedu.address.model.event;
 
 import javafx.collections.ObservableList;
 
+/**
+ * Unmodifiable view of the events list.
+ */
 public interface ReadOnlyEventManager {
     /**
      * Returns an unmodifiable view of the events list.

--- a/src/main/java/seedu/address/model/event/ReadOnlyEventManager.java
+++ b/src/main/java/seedu/address/model/event/ReadOnlyEventManager.java
@@ -1,0 +1,10 @@
+package seedu.address.model.event;
+
+import javafx.collections.ObservableList;
+
+public interface ReadOnlyEventManager {
+    /**
+     * Returns an unmodifiable view of the events list.
+     */
+    ObservableList<Event> getEventList();
+}

--- a/src/main/java/seedu/address/model/event/exceptions/EventException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/EventException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.event.exceptions;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+/**
+ * Represents a parse error encountered by an event.
+ */
+public class EventException extends IllegalValueException {
+    public EventException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/seedu/address/model/event/exceptions/EventNotFoundException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/EventNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.event.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified event.
+ */
+public class EventNotFoundException extends RuntimeException {}

--- a/src/test/java/seedu/address/model/event/EventListTest.java
+++ b/src/test/java/seedu/address/model/event/EventListTest.java
@@ -1,0 +1,121 @@
+package seedu.address.model.event;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.event.exceptions.EventNotFoundException;
+
+public class EventListTest {
+
+    private EventList eventList;
+    private Event event1;
+    private Event event2;
+    private Event event3;
+
+    @BeforeEach
+    public void setUp() {
+        eventList = new EventList();
+        event1 = new Event("event1");
+        event2 = new Event("event2");
+        event3 = new Event("event3");
+    }
+
+    @Test
+    public void contains_eventInList_returnsTrue() {
+        eventList.add(event1);
+        Assertions.assertTrue(eventList.contains(event1));
+    }
+
+    @Test
+    public void contains_eventNotInList_returnsFalse() {
+        Assertions.assertFalse(eventList.contains(event1));
+    }
+
+    @Test
+    public void add_event_success() {
+        eventList.add(event1);
+        Assertions.assertTrue(eventList.contains(event1));
+    }
+
+    @Test
+    public void remove_event_success() {
+        eventList.add(event1);
+        eventList.remove(event1);
+        Assertions.assertFalse(eventList.contains(event1));
+    }
+
+    @Test
+    public void remove_eventNotInList_throwsEventNotFoundException() {
+        Assertions.assertThrows(EventNotFoundException.class, () -> eventList.remove(event1));
+    }
+
+    @Test
+    public void setEvent_existingEvent_success() {
+        eventList.add(event1);
+        eventList.setEvent(event1, event2);
+        Assertions.assertFalse(eventList.contains(event1));
+        Assertions.assertTrue(eventList.contains(event2));
+    }
+
+    @Test
+    public void setEvent_nonExistentEvent_throwsEventNotFoundException() {
+        Assertions.assertThrows(EventNotFoundException.class, () -> eventList.setEvent(event1, event2));
+    }
+
+    @Test
+    public void setEvents_replaceAllEvents_success() {
+        List<Event> newEvents = new ArrayList<>();
+        newEvents.add(event2);
+        newEvents.add(event3);
+
+        eventList.setEvents(newEvents);
+
+        Assertions.assertTrue(eventList.contains(event2));
+        Assertions.assertTrue(eventList.contains(event3));
+        Assertions.assertFalse(eventList.contains(event1)); // No longer contains event1 since it was replaced
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_returnsCorrectList() {
+        eventList.add(event1);
+        eventList.add(event2);
+
+        ObservableList<Event> unmodifiableList = eventList.asUnmodifiableObservableList();
+
+        Assertions.assertEquals(FXCollections.unmodifiableObservableList(
+                FXCollections.observableArrayList(event1, event2)), unmodifiableList);
+    }
+
+    @Test
+    public void equals_sameList_returnsTrue() {
+        EventList otherList = new EventList();
+        otherList.add(event1);
+        eventList.add(event1);
+
+        Assertions.assertEquals(eventList, otherList);
+    }
+
+    @Test
+    public void equals_differentList_returnsFalse() {
+        EventList otherList = new EventList();
+        otherList.add(event1);
+        eventList.add(event2);
+
+        Assertions.assertNotEquals(eventList, otherList);
+    }
+
+    @Test
+    public void hashCode_sameList_returnsSameHashCode() {
+        eventList.add(event1);
+        EventList otherList = new EventList();
+        otherList.add(event1);
+
+        Assertions.assertEquals(eventList.hashCode(), otherList.hashCode());
+    }
+}

--- a/src/test/java/seedu/address/model/event/EventManagerTest.java
+++ b/src/test/java/seedu/address/model/event/EventManagerTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.event.exceptions.EventNotFoundException;
+
+public class EventManagerTest {
+
+    private EventManager eventManager;
+    private Event event1;
+    private Event event2;
+
+    @BeforeEach
+    public void setUp() {
+        eventManager = new EventManager();
+        event1 = new Event("event1");
+        event2 = new Event("event2");
+    }
+
+    @Test
+    public void addEvent_eventAddedSuccessfully() {
+        eventManager.addEvent(event1);
+        assertTrue(eventManager.getEventList().contains(event1));
+    }
+
+    @Test
+    public void removeEvent_eventRemovedSuccessfully() {
+        eventManager.addEvent(event1);
+        eventManager.removeEvent(event1);
+        assertFalse(eventManager.getEventList().contains(event1));
+    }
+
+    @Test
+    public void removeEvent_eventNotInList_throwsException() {
+        assertThrows(EventNotFoundException.class, () -> eventManager.removeEvent(event1));
+    }
+
+    @Test
+    public void setEvent_existingEvent_replacesSuccessfully() {
+        eventManager.addEvent(event1);
+        eventManager.setEvent(event1, event2);
+
+        ObservableList<Event> eventList = eventManager.getEventList();
+        assertFalse(eventList.contains(event1));
+        assertTrue(eventList.contains(event2));
+    }
+
+    @Test
+    public void setEvent_eventNotFound_throwsException() {
+        assertThrows(EventNotFoundException.class, () -> eventManager.setEvent(event1, event2));
+    }
+
+    @Test
+    public void getEventList_returnsUnmodifiableList() {
+        eventManager.addEvent(event1);
+        ObservableList<Event> unmodifiableList = eventManager.getEventList();
+
+        assertEquals(1, unmodifiableList.size());
+        assertThrows(UnsupportedOperationException.class, () -> unmodifiableList.add(event2));
+        // Ensure it's unmodifiable
+    }
+
+    @Test
+    public void getEventList_initialEmptyList() {
+        ObservableList<Event> eventList = eventManager.getEventList();
+        assertTrue(eventList.isEmpty());
+    }
+}
+


### PR DESCRIPTION
Fix #89 

Created a really basic EventManager class that abstracts away the work of handling many events at once, this is similar to what AddressBook class does when handling many Person classes.

This also implements an interface which provides an observableList object which is unmodifiable, which will be useful when implementing logic later on for the model and UI.