### PR TITLE
Add ID field to Person

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'PlanPal.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.role.Role;
@@ -27,6 +28,7 @@ public class Person implements Comparable<Person> {
 
     private final TelegramUsername telegramUsername;
     private final Set<Role> roles = new HashSet<>();
+    private UUID uniqueId;
 
     /**
      * Every field must be present and not null
@@ -41,26 +43,8 @@ public class Person implements Comparable<Person> {
         this.address = address;
         this.telegramUsername = telegramUsername;
         this.roles.addAll(roles);
+        this.uniqueId = UUID.randomUUID(); // Generate a unique ID
     }
-
-    /**
-     * Constructor that takes in a variable number of roles(optional field)
-     */
-    //    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags,
-    //                    TelegramUsername telegramUsername, Role... roles) {
-    //        requireAllNonNull(name, phone, email, address, tags);
-    //        this.name = name;
-    //        this.phone = phone;
-    //        this.email = email;
-    //        this.address = address;
-    //        this.tags.addAll(tags);
-    //        this.telegramUsername = telegramUsername;
-    //        for (Role role : roles) {
-    //            this.roles.add(role);
-    //        }
-    //
-    //    }
-
 
     public Name getName() {
         return name;
@@ -80,8 +64,6 @@ public class Person implements Comparable<Person> {
     public TelegramUsername getTelegramUsername() {
         return telegramUsername;
     }
-
-
 
 
     /**
@@ -117,9 +99,6 @@ public class Person implements Comparable<Person> {
                 || otherPerson.getEmail().equals(getEmail())
                 || otherPerson.getTelegramUsername().equals(getTelegramUsername());
     }
-
-
-
 
     /**
      * Returns true if both persons have the same phone number.
@@ -163,17 +142,14 @@ public class Person implements Comparable<Person> {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-
                 && telegramUsername.equals(otherPerson.telegramUsername)
                 && roles.equals(otherPerson.roles);
-
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, roles);
-
+        return Objects.hash(name, phone, email, address, telegramUsername, roles);
     }
 
     /**
@@ -182,7 +158,6 @@ public class Person implements Comparable<Person> {
     public boolean hasRole(Role role) {
         return roles.contains(role);
     }
-
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -84,13 +84,10 @@ class JsonAdaptedPerson {
      * @throws IllegalValueException if there were any data constraints violated in the adapted person.
      */
     public Person toModelType() throws IllegalValueException {
-
-
         final List<Role> personRoles = new ArrayList<>();
         for (JsonAdaptedRole role : roles) {
             personRoles.add(role.toModelType());
         }
-
 
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
@@ -126,23 +123,9 @@ class JsonAdaptedPerson {
 
         final TelegramUsername modelTelegramUsername = new TelegramUsername(telegramUsername);
 
-
-        //        Role[] roles = new Role[this.roles.size()];
-        //
-        //        if (this.roles.size() != 0) {
-        //            for (int i = 0; i < this.roles.size(); i++) {
-        //                try {
-        //                    roles[i] = this.roles.get(i).toModelType();
-        //                } catch (IllegalValueException e) {
-        //                    throw new RuntimeException(e);
-        //                }
-        //            }
-        //        }
-
         final Set<Role> modelRoles = new HashSet<>(personRoles);
         return new Person(modelName, modelPhone, modelEmail, modelAddress,
                 modelTelegramUsername, modelRoles);
-
     }
 
 }


### PR DESCRIPTION
Fixes #88 

Unique ID is generated using java.util.UUID library which ensures that the chance of duplicate IDs is extremely small. The ID is currently not added to the Person constructor yet, unless necessary for future implementations, which means that each Person will have a different ID every time on start up and the ID is not fixed on initial adding of the person to the address book.

Side addition:
- Enabled assertions for this week's tasks