### PR TITLE
Remove person from event

### DIFF
--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -53,14 +53,16 @@ public class RemovePersonFromEventCommand extends Command {
             throw new CommandException(MESSAGE_EVENT_NOT_FOUND);
         }
 
-        Event event = eventManager.getEventList().get(eventIndex.getZeroBased());
+        //this is a copy of event list -> copied event, have to set it back again
+        Event originalEvent = eventManager.getEventList().get(eventIndex.getZeroBased());
+        Event event = new Event(originalEvent);
 
         if (personIndex.getZeroBased() >= event.getAllPersons().size()) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
         }
         // get the person from address book, then remove from event
         List<Person> lastShownList = model.getFilteredPersonList();
-        Person person = lastShownList.get(eventIndex.getZeroBased());
+        Person person = lastShownList.get(personIndex.getZeroBased());
         String personRole = event.getRole(person);
         if (personRole == null) {
             throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
@@ -68,8 +70,10 @@ public class RemovePersonFromEventCommand extends Command {
         // at this point, person should have a role in event
         assert(event.hasPerson(person));
         logger.info("Removing person " + person.getName() + " from event " + event.getName());
+        logger.info(event.getName() + " now has " + event.getAllPersons().size() + " people");
 
         event.removePerson(person, personRole);
+        eventManager.setEvent(originalEvent, event);
         return new CommandResult(String.format(MESSAGE_SUCCESS, person.getName(), event.getName()));
 
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.commands.event.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Person;
+
+
+
+public class RemovePersonFromEventCommand extends Command {
+    private static final Logger logger = LogsCenter.getLogger(RemovePersonFromEventCommand.class);
+
+    public static final String COMMAND_WORD = "remove";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + "e/ [INDEX] [p/ [PERSON INDEX]] : Removes a person from " +
+            "an event";
+    public static final String MESSAGE_SUCCESS = "Person %1$s removed from event %2$s";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "Person not found in event";
+    public static final String MESSAGE_EVENT_NOT_FOUND = "Event not found";
+
+    private final Index eventIndex;
+    private final Index personIndex;
+
+    public RemovePersonFromEventCommand(Index eventIndex, Index personIndex) {
+        requireAllNonNull(eventIndex, personIndex);
+        this.eventIndex = eventIndex;
+        this.personIndex = personIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, EventManager eventManager) throws CommandException {
+        requireAllNonNull(model, eventManager);
+
+        if (eventIndex.getZeroBased() >= eventManager.getEventList().size()) {
+            throw new CommandException(MESSAGE_EVENT_NOT_FOUND);
+        }
+
+        Event event = eventManager.getEventList().get(eventIndex.getZeroBased());
+
+        if (personIndex.getZeroBased() >= event.getAllPersons().size()) {
+            throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+        }
+        // get the person from address book, then remove from event
+        List<Person> lastShownList = model.getFilteredPersonList();
+        Person person = lastShownList.get(eventIndex.getZeroBased());
+        String personRole = event.getRole(person);
+        if (personRole == null) {
+            throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+        }
+        // at this point, person should have a role in event
+        assert(event.hasPerson(person));
+        logger.info("Removing person " + person.getName() + " from event " + event.getName());
+
+        event.removePerson(person, personRole);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, person.getName(), event.getName()));
+
+
+
+
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -27,8 +27,9 @@ public class RemovePersonFromEventCommand extends Command {
     public static final String MESSAGE_PERSON_NOT_FOUND = "Person not found in event";
     public static final String MESSAGE_EVENT_NOT_FOUND = "Event not found";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " ei/ [INDEX] [pi/ [PERSON INDEX]] : Removes a person from "
-           + "an event";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + " ei/ [INDEX] [pi/ [PERSON INDEX]] : Removes a person from "
+            + "an event";
 
     private static final Logger logger = LogsCenter.getLogger(RemovePersonFromEventCommand.class);
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -17,20 +17,28 @@ import seedu.address.model.person.Person;
 
 
 
+/**
+ * Removes a person from an event
+ */
 public class RemovePersonFromEventCommand extends Command {
-    private static final Logger logger = LogsCenter.getLogger(RemovePersonFromEventCommand.class);
 
     public static final String COMMAND_WORD = "remove";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD + "e/ [INDEX] [p/ [PERSON INDEX]] : Removes a person from " +
-            "an event";
     public static final String MESSAGE_SUCCESS = "Person %1$s removed from event %2$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Person not found in event";
     public static final String MESSAGE_EVENT_NOT_FOUND = "Event not found";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " ei/ [INDEX] [pi/ [PERSON INDEX]] : Removes a person from "
+           + "an event";
+
+    private static final Logger logger = LogsCenter.getLogger(RemovePersonFromEventCommand.class);
+
+
     private final Index eventIndex;
     private final Index personIndex;
 
+    /**
+     * Creates a RemovePersonFromEventCommand to remove the specified {@code Person} from the specified {@code Event}
+     */
     public RemovePersonFromEventCommand(Index eventIndex, Index personIndex) {
         requireAllNonNull(eventIndex, personIndex);
         this.eventIndex = eventIndex;
@@ -67,6 +75,14 @@ public class RemovePersonFromEventCommand extends Command {
 
 
 
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RemovePersonFromEventCommand // instanceof handles nulls
+                && eventIndex.equals(((RemovePersonFromEventCommand) other).eventIndex)
+                && personIndex.equals(((RemovePersonFromEventCommand) other).personIndex)); // state check
     }
 
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.contact.commands.FindCommand;
 import seedu.address.logic.commands.contact.commands.ListCommand;
 import seedu.address.logic.commands.contact.commands.SearchCommand;
 import seedu.address.logic.commands.event.commands.AddEventCommand;
+import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case AddEventCommand.COMMAND_WORD:
             return new NewEventCommandParser().parse(arguments);
+
+        case RemovePersonFromEventCommand.COMMAND_WORD:
+            return new RemovePersonFromEventParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,4 +13,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_ROLE = new Prefix("r/");
     public static final Prefix PREFIX_TELEGRAM = new Prefix("t/");
 
+    public static final Prefix PREFIX_EVENT_INDEX = new Prefix("ei/");
+    public static final Prefix PREFIX_PERSON_INDEX = new Prefix("pi/");
+
+
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -190,4 +190,6 @@ public class ParserUtil {
         }
         return new Event(trimmedEvent);
     }
+
+
 }

--- a/src/main/java/seedu/address/logic/parser/RemovePersonFromEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemovePersonFromEventParser.java
@@ -3,11 +3,12 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.NoSuchElementException;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import java.util.NoSuchElementException;
 
 
 /**
@@ -35,9 +36,11 @@ public class RemovePersonFromEventParser implements Parser<RemovePersonFromEvent
             eventIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_EVENT_INDEX).get());
 
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemovePersonFromEventCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemovePersonFromEventCommand.MESSAGE_USAGE), pe);
         } catch (NoSuchElementException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemovePersonFromEventCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    RemovePersonFromEventCommand.MESSAGE_USAGE));
         }
 
 

--- a/src/main/java/seedu/address/logic/parser/RemovePersonFromEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemovePersonFromEventParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static java.util.Objects.requireNonNull;
+
+public class RemovePersonFromEventParser implements Parser<RemovePersonFromEventCommand> {
+
+    public RemovePersonFromEventCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                CliSyntax.PREFIX_EVENT_INDEX, CliSyntax.PREFIX_PERSON_INDEX);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(CliSyntax.PREFIX_EVENT_INDEX, CliSyntax.PREFIX_PERSON_INDEX);
+
+        Index personIndex;
+        Index eventIndex;
+
+        try {
+            personIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_PERSON_INDEX).get());
+            eventIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_EVENT_INDEX).get());
+
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(RemovePersonFromEventCommand.MESSAGE_USAGE), pe);
+        }
+
+
+        return new RemovePersonFromEventCommand(eventIndex, personIndex);
+
+    }
+
+
+
+
+}

--- a/src/main/java/seedu/address/logic/parser/RemovePersonFromEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemovePersonFromEventParser.java
@@ -1,13 +1,25 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import static java.util.Objects.requireNonNull;
+import java.util.NoSuchElementException;
 
+
+/**
+ * Parses input arguments and creates a new RemovePersonFromEventCommand object
+ */
 public class RemovePersonFromEventParser implements Parser<RemovePersonFromEventCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the RemovePersonFromEventCommand
+     * and returns a RemovePersonFromEventCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public RemovePersonFromEventCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
@@ -23,13 +35,17 @@ public class RemovePersonFromEventParser implements Parser<RemovePersonFromEvent
             eventIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_EVENT_INDEX).get());
 
         } catch (ParseException pe) {
-            throw new ParseException(String.format(RemovePersonFromEventCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemovePersonFromEventCommand.MESSAGE_USAGE), pe);
+        } catch (NoSuchElementException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemovePersonFromEventCommand.MESSAGE_USAGE));
         }
 
 
         return new RemovePersonFromEventCommand(eventIndex, personIndex);
 
     }
+
+
 
 
 

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -60,6 +60,18 @@ public class Event {
         this.volunteers = volunteers != null ? volunteers : new HashSet<>();
     }
 
+    /**
+     * Constructs a {@code Event} with the same attributes as the given {@code Event}.
+     * @param event Event to copy.
+     */
+    public Event(Event event) {
+        this.name = event.getName();
+        this.attendees = event.getAttendees();
+        this.vendors = event.getVendors();
+        this.sponsors = event.getSponsors();
+        this.volunteers = event.getVolunteers();
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -101,8 +101,46 @@ public class Event {
         return new HashSet<>(volunteers);
     }
 
+    /**
+     * Returns true if the person is in the event.
+     * @param p Person to check.
+     * @return True if the person is in the event.
+     */
+    public boolean hasPerson(Person p) {
+        return attendees.contains(p) || vendors.contains(p) || sponsors.contains(p) || volunteers.contains(p);
+    }
 
+    /**
+     * Returns the role of a person in the event, if not present, return null
+     * @param p Person to check.
+     * @return Role of the person in the event.
+     */
+    public String getRole(Person p) {
+        if (attendees.contains(p)) {
+            return "attendee";
+        } else if (vendors.contains(p)) {
+            return "vendor";
+        } else if (sponsors.contains(p)) {
+            return "sponsor";
+        } else if (volunteers.contains(p)) {
+            return "volunteer";
+        } else {
+            return null;
+        }
+    }
 
+    /**
+     * Returns all persons in the event.
+     * @return Set of all persons in the event.
+     */
+    public Set<Person> getAllPersons() {
+        Set<Person> allPersons = new HashSet<>();
+        allPersons.addAll(attendees);
+        allPersons.addAll(vendors);
+        allPersons.addAll(sponsors);
+        allPersons.addAll(volunteers);
+        return allPersons;
+    }
     /**
      * Adds a person to the event with the specified role.
      * @param person Person to be added.
@@ -140,6 +178,8 @@ public class Event {
             throw new IllegalValueException(e.getMessage());
         }
     }
+
+
 
     /**
      * Returns true if a given string is a valid event.

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
-import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -124,8 +123,12 @@ public class CommandTestUtil {
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
         List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
+        EventManager expectedEventManager = new EventManager(actualModel.getEventManager());
 
-        assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel, new EventManager()));
+        //Not sure what this commented out line does, removed it for now
+        //assertThrows(CommandException.class, expectedMessage,
+        // () -> command.execute(actualModel, new EventManager()));
+        assertEquals(expectedEventManager, actualModel.getEventManager());
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -125,9 +126,8 @@ public class CommandTestUtil {
         List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
         EventManager expectedEventManager = new EventManager(actualModel.getEventManager());
 
-        //Not sure what this commented out line does, removed it for now
-        //assertThrows(CommandException.class, expectedMessage,
-        // () -> command.execute(actualModel, new EventManager()));
+        assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel,
+                actualModel.getEventManager()));
         assertEquals(expectedEventManager, actualModel.getEventManager());
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());

--- a/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
@@ -111,10 +111,20 @@ public class RemovePersonFromEventCommandTest {
     }
 
 
+
+    @Test
+    public void execute_invalidEventIndexLarge_throwsCommandException() {
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
+                Index.fromOneBased(99), INDEX_FIRST_PERSON);
+        assertCommandFailure(removePersonFromEventCommand, model,
+                RemovePersonFromEventCommand.MESSAGE_EVENT_NOT_FOUND);
+    }
+
+
     @Test
     public void equals_sameCommand_returnsTrue() {
         RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
-                Index.fromOneBased(1), INDEX_FIRST_PERSON);
+                Index.fromOneBased(21), INDEX_FIRST_PERSON);
         assertEquals(removePersonFromEventCommand, removePersonFromEventCommand);
     }
 

--- a/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventManager;
+import seedu.address.testutil.TypicalPersons;
 
 
 public class RemovePersonFromEventCommandTest {
@@ -57,7 +58,7 @@ public class RemovePersonFromEventCommandTest {
     * FIONA = 5
     * GEORGE = 6
      *
-     * Unused Persons:
+     * Unused Persons Not in TypicalPersons:
      * HOON = 7
      *
     */
@@ -104,21 +105,23 @@ public class RemovePersonFromEventCommandTest {
 
     @Test
     public void execute_personNotInEvent_throwsCommandException() {
+        model.addPerson(TypicalPersons.HOON);
         RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
                 Index.fromOneBased(1), Index.fromOneBased(7));
         assertCommandFailure(removePersonFromEventCommand, model,
                 RemovePersonFromEventCommand.MESSAGE_PERSON_NOT_FOUND);
     }
 
-
-
     @Test
-    public void execute_invalidEventIndexLarge_throwsCommandException() {
+    public void execute_personOutOfIndex_throwsCommandException() {
         RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
-                Index.fromOneBased(99), INDEX_FIRST_PERSON);
+                Index.fromOneBased(1), Index.fromOneBased(99));
         assertCommandFailure(removePersonFromEventCommand, model,
-                RemovePersonFromEventCommand.MESSAGE_EVENT_NOT_FOUND);
+                RemovePersonFromEventCommand.MESSAGE_PERSON_NOT_FOUND);
     }
+
+
+
 
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
@@ -2,82 +2,60 @@ package seedu.address.logic.commands;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.lang.reflect.Method;
-import java.util.HashSet;
-import java.util.Set;
-
-import javafx.collections.ObservableList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
-import seedu.address.logic.commands.contact.commands.ClearCommand;
-import seedu.address.logic.commands.contact.commands.EditCommand;
-import seedu.address.logic.commands.contact.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
-import seedu.address.model.event.EventList;
 import seedu.address.model.event.EventManager;
-import seedu.address.model.person.Person;
-import seedu.address.testutil.EditPersonDescriptorBuilder;
-import seedu.address.testutil.EventBuilder;
-import seedu.address.testutil.PersonBuilder;
-import seedu.address.testutil.TypicalPersons;
+
 
 public class RemovePersonFromEventCommandTest {
 
-    /** TypicalEvents have the following Events, displayin in order:
-     * public static final Event TECH_CONFERENCE = new EventBuilder().withName("Tech Conference 2024")
-     *             .withAttendees(getPersonSet(TypicalPersons.ALICE, TypicalPersons.FIONA))
-     *             .withVendors(getPersonSet(TypicalPersons.DANIEL))
-     *             .withSponsors(getPersonSet(TypicalPersons.BENSON, TypicalPersons.CARL))
-     *             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
-     *             .build();
-     *
-     *     public static final Event ART_EXHIBITION = new EventBuilder().withName("Art Exhibition 2024")
-     *             .withAttendees(getPersonSet(TypicalPersons.BOB))
-     *             .withVendors(getPersonSet(TypicalPersons.AMY, TypicalPersons.GEORGE))
-     *             .withSponsors(getPersonSet(TypicalPersons.BENSON))
-     *             .withVolunteers(getPersonSet(TypicalPersons.HOON, TypicalPersons.IDA))
-     *             .build();
-     *
-     *     // Manually added events
-     *     public static final Event SPORTS_FESTIVAL = new EventBuilder().withName("Sports Festival")
-     *             .withAttendees(getPersonSet(TypicalPersons.ALICE))
-     *             .withVendors(getPersonSet(TypicalPersons.DANIEL))
-     *             .withSponsors(getPersonSet(TypicalPersons.BENSON))
-     *             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
-     *             .build();
-     *
     /**
-     * Persons used and index in TypicalPersons
-     * ALICE = 0
-     * BENSON = 1
-     * CARL = 2
-     * DANIEL = 3
-     * ELLE = 4
-     * FIONA = 5
-     * GEORGE = 6
-     */
+    * TypicalEvents have the following Events, displayin in order:
+    * public static final Event TECH_CONFERENCE = new EventBuilder().withName("Tech Conference 2024")
+    *             .withAttendees(getPersonSet(TypicalPersons.ALICE, TypicalPersons.FIONA))
+    *             .withVendors(getPersonSet(TypicalPersons.DANIEL))
+    *             .withSponsors(getPersonSet(TypicalPersons.BENSON, TypicalPersons.CARL))
+    *             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
+    *             .build();
+    *
+    *     public static final Event ART_EXHIBITION = new EventBuilder().withName("Art Exhibition 2024")
+    *             .withAttendees(getPersonSet(TypicalPersons.BOB))
+    *             .withVendors(getPersonSet(TypicalPersons.AMY, TypicalPersons.GEORGE))
+    *             .withSponsors(getPersonSet(TypicalPersons.BENSON))
+    *             .withVolunteers(getPersonSet(TypicalPersons.HOON, TypicalPersons.IDA))
+    *             .build();
+    *
+    *     // Manually added events
+    *     public static final Event SPORTS_FESTIVAL = new EventBuilder().withName("Sports Festival")
+    *             .withAttendees(getPersonSet(TypicalPersons.ALICE))
+    *             .withVendors(getPersonSet(TypicalPersons.DANIEL))
+    *             .withSponsors(getPersonSet(TypicalPersons.BENSON))
+    *             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
+    *             .build();
+    *
+    *
+    *
+    * Persons used and index in TypicalPersons
+    * ALICE = 0
+    * BENSON = 1
+    * CARL = 2
+    * DANIEL = 3
+    * ELLE = 4
+    * FIONA = 5
+    * GEORGE = 6
+    */
     private Model model;
 
     private Event validEvent;
@@ -95,8 +73,8 @@ public class RemovePersonFromEventCommandTest {
 
         assertEquals(eventManager.getEventList().get(0).getAllPersons().size(), 6);
         // Remove ALICE from TECH_CONFERENCE
-        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand
-                (Index.fromOneBased(1), INDEX_FIRST_PERSON);
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
+                Index.fromOneBased(1), INDEX_FIRST_PERSON);
         removePersonFromEventCommand.execute(model, eventManager);
         //check no. of people in TECH_CONFERENCE
         Event techConference = eventManager.getEventList().get(0);
@@ -107,8 +85,8 @@ public class RemovePersonFromEventCommandTest {
     @Test
     public void execute_invalidEventIndex_throwsCommandException() {
         EventManager eventManager = model.getEventManager();
-        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand
-                (Index.fromOneBased(3), INDEX_FIRST_PERSON);
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
+                Index.fromOneBased(3), INDEX_FIRST_PERSON);
         assertCommandFailure(removePersonFromEventCommand, model, RemovePersonFromEventCommand.MESSAGE_EVENT_NOT_FOUND);
     }
 

--- a/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
@@ -90,7 +90,7 @@ public class RemovePersonFromEventCommandTest {
     @Test
     public void execute_invalidEventIndex_throwsCommandException() {
         RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
-                Index.fromOneBased(3), INDEX_FIRST_PERSON);
+                Index.fromOneBased(9), INDEX_FIRST_PERSON);
         assertCommandFailure(removePersonFromEventCommand, model, RemovePersonFromEventCommand.MESSAGE_EVENT_NOT_FOUND);
     }
 

--- a/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -55,6 +56,10 @@ public class RemovePersonFromEventCommandTest {
     * ELLE = 4
     * FIONA = 5
     * GEORGE = 6
+     *
+     * Unused Persons:
+     * HOON = 7
+     *
     */
     private Model model;
 
@@ -84,12 +89,43 @@ public class RemovePersonFromEventCommandTest {
 
     @Test
     public void execute_invalidEventIndex_throwsCommandException() {
-        EventManager eventManager = model.getEventManager();
         RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
                 Index.fromOneBased(3), INDEX_FIRST_PERSON);
         assertCommandFailure(removePersonFromEventCommand, model, RemovePersonFromEventCommand.MESSAGE_EVENT_NOT_FOUND);
     }
 
+    @Test
+    public void execute_invalidPersonIndex_throwsCommandException() {
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
+                Index.fromOneBased(1), Index.fromOneBased(7));
+        assertCommandFailure(removePersonFromEventCommand, model,
+                RemovePersonFromEventCommand.MESSAGE_PERSON_NOT_FOUND);
+    }
+
+    @Test
+    public void execute_personNotInEvent_throwsCommandException() {
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
+                Index.fromOneBased(1), Index.fromOneBased(7));
+        assertCommandFailure(removePersonFromEventCommand, model,
+                RemovePersonFromEventCommand.MESSAGE_PERSON_NOT_FOUND);
+    }
+
+
+    @Test
+    public void equals_sameCommand_returnsTrue() {
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
+                Index.fromOneBased(1), INDEX_FIRST_PERSON);
+        assertEquals(removePersonFromEventCommand, removePersonFromEventCommand);
+    }
+
+    @Test
+    public void equals_sameCommandDifferentIndex_returnsFalse() {
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand(
+                Index.fromOneBased(1), INDEX_FIRST_PERSON);
+        RemovePersonFromEventCommand removePersonFromEventCommand2 = new RemovePersonFromEventCommand(
+                Index.fromOneBased(1), Index.fromOneBased(2));
+        assertNotEquals(removePersonFromEventCommand, removePersonFromEventCommand2);
+    }
 
 
 }

--- a/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemovePersonFromEventCommandTest.java
@@ -1,0 +1,117 @@
+package seedu.address.logic.commands;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import javafx.collections.ObservableList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.contact.commands.ClearCommand;
+import seedu.address.logic.commands.contact.commands.EditCommand;
+import seedu.address.logic.commands.contact.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventList;
+import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.EventBuilder;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalPersons;
+
+public class RemovePersonFromEventCommandTest {
+
+    /** TypicalEvents have the following Events, displayin in order:
+     * public static final Event TECH_CONFERENCE = new EventBuilder().withName("Tech Conference 2024")
+     *             .withAttendees(getPersonSet(TypicalPersons.ALICE, TypicalPersons.FIONA))
+     *             .withVendors(getPersonSet(TypicalPersons.DANIEL))
+     *             .withSponsors(getPersonSet(TypicalPersons.BENSON, TypicalPersons.CARL))
+     *             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
+     *             .build();
+     *
+     *     public static final Event ART_EXHIBITION = new EventBuilder().withName("Art Exhibition 2024")
+     *             .withAttendees(getPersonSet(TypicalPersons.BOB))
+     *             .withVendors(getPersonSet(TypicalPersons.AMY, TypicalPersons.GEORGE))
+     *             .withSponsors(getPersonSet(TypicalPersons.BENSON))
+     *             .withVolunteers(getPersonSet(TypicalPersons.HOON, TypicalPersons.IDA))
+     *             .build();
+     *
+     *     // Manually added events
+     *     public static final Event SPORTS_FESTIVAL = new EventBuilder().withName("Sports Festival")
+     *             .withAttendees(getPersonSet(TypicalPersons.ALICE))
+     *             .withVendors(getPersonSet(TypicalPersons.DANIEL))
+     *             .withSponsors(getPersonSet(TypicalPersons.BENSON))
+     *             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
+     *             .build();
+     *
+    /**
+     * Persons used and index in TypicalPersons
+     * ALICE = 0
+     * BENSON = 1
+     * CARL = 2
+     * DANIEL = 3
+     * ELLE = 4
+     * FIONA = 5
+     * GEORGE = 6
+     */
+    private Model model;
+
+    private Event validEvent;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
+
+    }
+
+
+    @Test
+    public void execute_validUnfilteredList_success() throws Exception {
+        EventManager eventManager = model.getEventManager();
+
+        assertEquals(eventManager.getEventList().get(0).getAllPersons().size(), 6);
+        // Remove ALICE from TECH_CONFERENCE
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand
+                (Index.fromOneBased(1), INDEX_FIRST_PERSON);
+        removePersonFromEventCommand.execute(model, eventManager);
+        //check no. of people in TECH_CONFERENCE
+        Event techConference = eventManager.getEventList().get(0);
+        assertEquals(techConference.getAllPersons().size(), 5);
+
+    }
+
+    @Test
+    public void execute_invalidEventIndex_throwsCommandException() {
+        EventManager eventManager = model.getEventManager();
+        RemovePersonFromEventCommand removePersonFromEventCommand = new RemovePersonFromEventCommand
+                (Index.fromOneBased(3), INDEX_FIRST_PERSON);
+        assertCommandFailure(removePersonFromEventCommand, model, RemovePersonFromEventCommand.MESSAGE_EVENT_NOT_FOUND);
+    }
+
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -25,6 +26,7 @@ import seedu.address.logic.commands.contact.commands.FindCommand;
 import seedu.address.logic.commands.contact.commands.ListCommand;
 import seedu.address.logic.commands.contact.commands.SearchCommand;
 import seedu.address.logic.commands.event.commands.AddEventCommand;
+import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Event;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -126,5 +128,13 @@ public class AddressBookParserTest {
         Command expected = new AddEventCommand(new Event("sumo bot festival"));
         assertEquals(expected, new AddressBookParser()
                 .parseCommand(AddEventCommand.COMMAND_WORD + " sumo bot festival"));
+    }
+
+    @Test
+    public void parseCommand_removePersonFromEvent() throws ParseException {
+        Command expected = new RemovePersonFromEventCommand(Index.fromOneBased(1),
+                Index.fromOneBased(1));
+        assertEquals(expected, new AddressBookParser()
+                .parseCommand(RemovePersonFromEventCommand.COMMAND_WORD + " ei/1 pi/1"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/RemovePersonFromEventParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemovePersonFromEventParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 
@@ -16,7 +17,7 @@ public class RemovePersonFromEventParserTest {
     private RemovePersonFromEventParser parser = new RemovePersonFromEventParser();
 
     @Test
-    public void parse_MissingParts_Failure() {
+    public void parse_missingParts_failure() {
         // no index specified
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
@@ -29,7 +30,7 @@ public class RemovePersonFromEventParserTest {
 
     @Test
     public void parse_validArgs_returnsRemovePersonFromEventCommand() {
-         assertParseSuccess(parser, "remove ei/1 pi/1",
+        assertParseSuccess(parser, "remove ei/1 pi/1",
                  new RemovePersonFromEventCommand(Index.fromOneBased(1),
                          Index.fromOneBased(1)));
     }

--- a/src/test/java/seedu/address/logic/parser/RemovePersonFromEventParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemovePersonFromEventParserTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
+
+
+public class RemovePersonFromEventParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemovePersonFromEventCommand.MESSAGE_USAGE);
+    private RemovePersonFromEventParser parser = new RemovePersonFromEventParser();
+
+    @Test
+    public void parse_MissingParts_Failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_validArgs_returnsRemovePersonFromEventCommand() {
+         assertParseSuccess(parser, "remove ei/1 pi/1",
+                 new RemovePersonFromEventCommand(Index.fromOneBased(1),
+                         Index.fromOneBased(1)));
+    }
+
+    @Test
+    public void parse_validArgs_differentOrder() {
+        assertParseSuccess(parser, "remove pi/1 ei/2",
+                new RemovePersonFromEventCommand(Index.fromOneBased(2),
+                        Index.fromOneBased(1)));
+    }
+}

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
+
+
 
 public class EventTest {
 
@@ -220,5 +223,29 @@ public class EventTest {
     @Test
     public void isValidEvent_invalidInput_false() {
         assertFalse(Event.isValidEvent(""));
+    }
+
+    @Test
+    public void getRole_validRole_true() {
+        try {
+            Event event = new Event("Event1");
+            Person personAttendee = new PersonBuilder().withRoles("attendee").build();
+            event.addPerson(personAttendee, "attendee");
+            assertEquals("attendee", event.getRole(personAttendee));
+            Person personVendor = new PersonBuilder().withRoles("vendor").build();
+            event.addPerson(personVendor, "vendor");
+            assertEquals("vendor", event.getRole(personVendor));
+            Person personSponsor = new PersonBuilder().withRoles("sponsor").build();
+            event.addPerson(personSponsor, "sponsor");
+            assertEquals("sponsor", event.getRole(personSponsor));
+            Person personVolunteer = new PersonBuilder().withRoles("volunteer").build();
+            event.addPerson(personVolunteer, "volunteer");
+            assertEquals("volunteer", event.getRole(personVolunteer));
+            Person personNoRole = new PersonBuilder().build();
+            assertNull(event.getRole(personNoRole));
+        } catch (Exception e) {
+            assert false;
+        }
+
     }
 }


### PR DESCRIPTION
For #108 
Adds `RemovePersonFromEventCommand` and `RemovePersonFromEventParser`

To remove a person from event: 
`remove ei/ [EventIndex] pi/ [PersonIndex]`

Changes to other classes:
- new prefixes in `CliSyntax`: 
	- `ei`:event index
	- `pi`: person index
- Event Class 
	- new constructor `new Event(Event other)`
		- Creates a copy of the event
	- `String getRole(Person)`
		- Gets string form of the role a person has in an event
	- `Set<Person> getAllPersons()`
		- Gets a Set<Person> with all Persons in a role for the event