### PR TITLE
Add contacts to events

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -66,4 +66,8 @@ public class Index {
     public String toString() {
         return new ToStringBuilder(this).add("zeroBasedIndex", zeroBasedIndex).toString();
     }
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(zeroBasedIndex); // Ensures hashCode matches equals() for `value`
+    }
 }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,7 +14,11 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX = "The contact index provided is invalid";
+    public static final String MESSAGE_MULTIPLE_INVALID_CONTACT_DISPLAYED_INDEX = "One or more of the contact indices " +
+            "provided is invalid";
+    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is greater than the " +
+            "total number of events in your event list now";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,10 +15,10 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX = "The contact index provided is invalid";
-    public static final String MESSAGE_MULTIPLE_INVALID_CONTACT_DISPLAYED_INDEX = "One or more of the contact indices " +
-            "provided is invalid";
-    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is greater than the " +
-            "total number of events in your event list now";
+    public static final String MESSAGE_MULTIPLE_INVALID_CONTACT_DISPLAYED_INDEX = "One or more of the contact "
+            + "indices provided is invalid";
+    public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is greater than the "
+            + "total number of events in your event list now";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/commands/contact/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/DeleteCommand.java
@@ -40,7 +40,7 @@ public class DeleteCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/contact/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/EditCommand.java
@@ -82,7 +82,7 @@ public class EditCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands.event.commands;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
@@ -18,11 +17,16 @@ import seedu.address.model.event.Event;
 import seedu.address.model.event.EventManager;
 import seedu.address.model.person.Person;
 
+/**
+ * Adds contacts to an event in to the address book.
+ */
 public class AddPersonToEventCommand extends Command {
     public static final String COMMAND_WORD = "event-add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " ei/ [Event Index] [a/e/ve/vo]/ [Contact Index]: " +
-            "Adds contacts to an event in the address book. e.g. event-add ei/1 a/1,2,3";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " ei/EVENT INDEX [a/ or s/ or ve/ or vo/] CONTACT "
+            + "INDEX \nAdds contacts to an event in the address book. \nNote: At least one of the following prefixes "
+            + "is required—`a/`, `e/`, `ve/`, or `vo/`—each followed by one or more contact index/indices \ne.g. "
+            + "event-add ei/1 a/1,2,3";
 
     public static final String MESSAGE_SUCCESS = "Contacts added to %2$s successfully: \n%1$s";
 
@@ -32,6 +36,23 @@ public class AddPersonToEventCommand extends Command {
     private final Set<Index> vendors;
     private final Set<Index> sponsors;
 
+    /**
+     * Constructs an {@code AddPersonToEventCommand} to add specified persons
+     * to an event identified by the given event index.
+     *
+     * @param eventIndex The index of the event to which persons will be added.
+     *                   This cannot be null.
+     * @param attendees A set of indices representing the attendees to be added
+     *                  to the event. This cannot be null.
+     * @param volunteers A set of indices representing the volunteers to be added
+     *                   to the event. This cannot be null.
+     * @param vendors A set of indices representing the vendors to be added
+     *                to the event. This cannot be null.
+     * @param sponsors A set of indices representing the sponsors to be added
+     *                 to the event. This cannot be null.
+     *
+     * @throws NullPointerException if any of the parameters are null.
+     */
     public AddPersonToEventCommand(Index eventIndex, Set<Index> attendees, Set<Index> volunteers, Set<Index> vendors,
                                    Set<Index> sponsors) {
         requireAllNonNull(eventIndex, attendees, volunteers, vendors, sponsors);
@@ -67,12 +88,10 @@ public class AddPersonToEventCommand extends Command {
             addContactsToEvent(vendors, lastShownList, event, "vendor", sb);
             addContactsToEvent(sponsors, lastShownList, event, "sponsor", sb);
         } catch (IllegalValueException e) {
-            throw new CommandException("One or more person(s) to be added does not have the role that you are " +
-                    "adding him or her to. For example, to add a person as an attendee of Event X, make sure he or she " +
-                    "has the attendee role.");
+            throw new CommandException(e.getMessage());
         }
 
-        sb.delete(sb.length() - 2, sb.length());
+        sb.delete(sb.length() - 1, sb.length());
         return new CommandResult(String.format(MESSAGE_SUCCESS, sb, event.getName()));
     }
 
@@ -119,6 +138,9 @@ public class AddPersonToEventCommand extends Command {
             throws IllegalValueException {
         assert role != null;
         assert !role.isEmpty();
+        if (indices.isEmpty()) {
+            return;
+        }
         addRoleToMsg(indices, role, sb);
         for (Index index : indices) {
             Person person = persons.get(index.getZeroBased());
@@ -127,14 +149,13 @@ public class AddPersonToEventCommand extends Command {
         }
         sb.delete(sb.length() - 2, sb.length());
         sb.append("\n");
+
     }
 
     private static void addRoleToMsg(Set<Index> indices, String role, StringBuilder sb) {
-        if (!indices.isEmpty()) {
-            //format role
-            sb.append(role.substring(0, 1).toUpperCase())
-                    .append(role.substring(1))
-                    .append("(s): ");
-        }
+        //format role
+        sb.append(role.substring(0, 1).toUpperCase())
+                .append(role.substring(1))
+                .append("(s): ");
     }
 }

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
@@ -1,0 +1,140 @@
+package seedu.address.logic.commands.event.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Person;
+
+public class AddPersonToEventCommand extends Command {
+    public static final String COMMAND_WORD = "event-add";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " ei/ [Event Index] [a/e/ve/vo]/ [Contact Index]: " +
+            "Adds contacts to an event in the address book. e.g. event-add ei/1 a/1,2,3";
+
+    public static final String MESSAGE_SUCCESS = "Contacts added to %2$s successfully: \n%1$s";
+
+    private final Index eventIndex;
+    private final Set<Index> attendees;
+    private final Set<Index> volunteers;
+    private final Set<Index> vendors;
+    private final Set<Index> sponsors;
+
+    public AddPersonToEventCommand(Index eventIndex, Set<Index> attendees, Set<Index> volunteers, Set<Index> vendors,
+                                   Set<Index> sponsors) {
+        requireAllNonNull(eventIndex, attendees, volunteers, vendors, sponsors);
+        this.eventIndex = eventIndex;
+        this.attendees = attendees;
+        this.volunteers = volunteers;
+        this.vendors = vendors;
+        this.sponsors = sponsors;
+    }
+
+    @Override
+    public CommandResult execute(Model model, EventManager eventManager) throws CommandException {
+        requireAllNonNull(model, eventManager);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        List<Event> events = eventManager.getEventList();
+        int size = lastShownList.size();
+
+        checkValidIndex(attendees, size);
+        checkValidIndex(volunteers, size);
+        checkValidIndex(vendors, size);
+        checkValidIndex(sponsors, size);
+
+        if (eventIndex.getZeroBased() >= events.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+        }
+
+        Event event = events.get(eventIndex.getZeroBased());
+        StringBuilder sb = new StringBuilder();
+
+        try {
+            addContactsToEvent(attendees, lastShownList, event, "attendee", sb);
+            addContactsToEvent(volunteers, lastShownList, event, "volunteer", sb);
+            addContactsToEvent(vendors, lastShownList, event, "vendor", sb);
+            addContactsToEvent(sponsors, lastShownList, event, "sponsor", sb);
+        } catch (IllegalValueException e) {
+            throw new CommandException("One or more person(s) to be added does not have the role that you are " +
+                    "adding him or her to. For example, to add a person as an attendee of Event X, make sure he or she " +
+                    "has the attendee role.");
+        }
+
+        sb.delete(sb.length() - 2, sb.length());
+        return new CommandResult(String.format(MESSAGE_SUCCESS, sb, event.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddPersonToEventCommand)) {
+            return false;
+        }
+
+        AddPersonToEventCommand otherAddPersonToEventCommand = (AddPersonToEventCommand) other;
+        return eventIndex.equals(otherAddPersonToEventCommand.eventIndex)
+                && attendees.equals(otherAddPersonToEventCommand.attendees)
+                && volunteers.equals(otherAddPersonToEventCommand.volunteers)
+                && vendors.equals(otherAddPersonToEventCommand.vendors)
+                && sponsors.equals(otherAddPersonToEventCommand.sponsors);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("eventIndex", eventIndex)
+                .add("attendees", attendees)
+                .add("volunteers", volunteers)
+                .add("vendors", vendors)
+                .add("sponsors", sponsors)
+                .toString();
+    }
+
+    private void checkValidIndex(Set<Index> indices, int size) throws CommandException {
+        for (Index index : indices) {
+            if (index.getZeroBased() >= size) {
+                throw new CommandException(Messages.MESSAGE_MULTIPLE_INVALID_CONTACT_DISPLAYED_INDEX);
+            }
+        }
+    }
+
+    private void addContactsToEvent(Set<Index> indices, List<Person> persons, Event event, String role,
+                                    StringBuilder sb)
+            throws IllegalValueException {
+        assert role != null;
+        assert !role.isEmpty();
+        addRoleToMsg(indices, role, sb);
+        for (Index index : indices) {
+            Person person = persons.get(index.getZeroBased());
+            event.addPerson(person, role);
+            sb.append(person.getName()).append(", ");
+        }
+        sb.delete(sb.length() - 2, sb.length());
+        sb.append("\n");
+    }
+
+    private static void addRoleToMsg(Set<Index> indices, String role, StringBuilder sb) {
+        if (!indices.isEmpty()) {
+            //format role
+            sb.append(role.substring(0, 1).toUpperCase())
+                    .append(role.substring(1))
+                    .append("(s): ");
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,7 +19,16 @@ import seedu.address.logic.commands.contact.commands.FindCommand;
 import seedu.address.logic.commands.contact.commands.ListCommand;
 import seedu.address.logic.commands.contact.commands.SearchCommand;
 import seedu.address.logic.commands.event.commands.AddEventCommand;
+import seedu.address.logic.commands.event.commands.AddPersonToEventCommand;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
+import seedu.address.logic.parser.contact.parser.AddCommandParser;
+import seedu.address.logic.parser.contact.parser.DeleteCommandParser;
+import seedu.address.logic.parser.contact.parser.EditCommandParser;
+import seedu.address.logic.parser.contact.parser.FindCommandParser;
+import seedu.address.logic.parser.contact.parser.SearchCommandParser;
+import seedu.address.logic.parser.event.parser.AddPersonToEventParser;
+import seedu.address.logic.parser.event.parser.NewEventCommandParser;
+import seedu.address.logic.parser.event.parser.RemovePersonFromEventParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -88,6 +97,9 @@ public class AddressBookParser {
 
         case RemovePersonFromEventCommand.COMMAND_WORD:
             return new RemovePersonFromEventParser().parse(arguments);
+
+        case AddPersonToEventCommand.COMMAND_WORD:
+            return new AddPersonToEventParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,10 @@ public class CliSyntax {
 
     public static final Prefix PREFIX_EVENT_INDEX = new Prefix("ei/");
     public static final Prefix PREFIX_PERSON_INDEX = new Prefix("pi/");
+    public static final Prefix PREFIX_ATTENDEE = new Prefix("a/");
+    public static final Prefix PREFIX_VOLUNTEER = new Prefix("vo/");
+    public static final Prefix PREFIX_SPONSOR = new Prefix("s/");
+    public static final Prefix PREFIX_VENDOR = new Prefix("ve/");
 
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -191,6 +191,19 @@ public class ParserUtil {
         return new Event(trimmedEvent);
     }
 
+    /**
+     * Parses a string of comma-separated indices and adds them to the provided set.
+     * Each index is trimmed of whitespace and validated to ensure it is a non-zero unsigned integer.
+     *
+     * @param indices The set to which the parsed indices will be added.
+     *                It should not be null.
+     * @param string The string containing comma-separated indices.
+     *               If null, no action is taken.
+     *
+     * @throws ParseException If the string is not null and one or more indices
+     *                        are invalid (not a non-zero unsigned integer) or
+     *                        if there are duplicate indices in the string.
+     */
     public static void parseStringOfIndices(Set<Index> indices, String string) throws ParseException {
         if (string == null) {
             return; // skip cuz tag is not part of input
@@ -206,7 +219,10 @@ public class ParserUtil {
                 throw new ParseException("One or more of the contact indices is not a non-zero unsigned integer.");
             }
 
-            indices.add(index); // duplicates are simply ignored, based on equals method of Index
+            if (indices.contains(index)) {
+                throw new ParseException("There cannot be duplicate indices for the same role e.g. a/1,1");
+            }
+            indices.add(index);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -191,5 +191,22 @@ public class ParserUtil {
         return new Event(trimmedEvent);
     }
 
+    public static void parseStringOfIndices(Set<Index> indices, String string) throws ParseException {
+        if (string == null) {
+            return; // skip cuz tag is not part of input
+        }
 
+        String[] strings = string.split(",");
+
+        for (String str : strings) {
+            Index index;
+            try {
+                index = ParserUtil.parseIndex(str.trim());
+            } catch (ParseException e) {
+                throw new ParseException("One or more of the contact indices is not a non-zero unsigned integer.");
+            }
+
+            indices.add(index); // duplicates are simply ignored, based on equals method of Index
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/contact/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/parser/AddCommandParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
@@ -12,6 +12,11 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.contact.commands.AddCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;

--- a/src/main/java/seedu/address/logic/parser/contact/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/parser/DeleteCommandParser.java
@@ -1,9 +1,11 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.contact.commands.DeleteCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/contact/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/parser/EditCommandParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
@@ -17,6 +17,10 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.contact.commands.EditCommand;
 import seedu.address.logic.commands.contact.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.role.Role;
 

--- a/src/main/java/seedu/address/logic/parser/contact/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/parser/FindCommandParser.java
@@ -1,10 +1,11 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 
 import seedu.address.logic.commands.contact.commands.FindCommand;
+import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 

--- a/src/main/java/seedu/address/logic/parser/contact/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/parser/SearchCommandParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.ParserUtil.parseRole;
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.logic.commands.contact.commands.SearchCommand;
+import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonIsRolePredicate;
 import seedu.address.model.role.Role;

--- a/src/main/java/seedu/address/logic/parser/event/parser/AddPersonToEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/parser/AddPersonToEventParser.java
@@ -1,0 +1,76 @@
+package seedu.address.logic.parser.event.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDEE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_INDEX;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SPONSOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_VOLUNTEER;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.commands.AddPersonToEventCommand;
+import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.CliSyntax;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class AddPersonToEventParser implements Parser<AddPersonToEventCommand> {
+    public AddPersonToEventCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_EVENT_INDEX, PREFIX_ATTENDEE, PREFIX_VOLUNTEER, PREFIX_SPONSOR, PREFIX_VENDOR);
+
+        if (!areNecessaryPrefixesPresent(argMultimap, PREFIX_EVENT_INDEX, PREFIX_ATTENDEE, PREFIX_VOLUNTEER,
+                PREFIX_SPONSOR, PREFIX_VENDOR)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddPersonToEventCommand.MESSAGE_USAGE));
+        }
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EVENT_INDEX, PREFIX_ATTENDEE,
+                PREFIX_VOLUNTEER, PREFIX_SPONSOR, PREFIX_VENDOR);
+
+        Index eventIndex;
+        Set<Index> attendees = new HashSet<>();
+        Set<Index> volunteers = new HashSet<>();
+        Set<Index> vendors = new HashSet<>();
+        Set<Index> sponsors = new HashSet<>();
+
+        eventIndex = getEventIndex(argMultimap);
+        ParserUtil.parseStringOfIndices(attendees, argMultimap.getValue(PREFIX_ATTENDEE).orElse(null));
+        ParserUtil.parseStringOfIndices(volunteers, argMultimap.getValue(PREFIX_VOLUNTEER).orElse(null));
+        ParserUtil.parseStringOfIndices(vendors, argMultimap.getValue(PREFIX_VENDOR).orElse(null));
+        ParserUtil.parseStringOfIndices(sponsors,argMultimap.getValue(PREFIX_SPONSOR).orElse(null));
+
+        return new AddPersonToEventCommand(eventIndex, attendees, volunteers, vendors, sponsors);
+    }
+
+    private static Index getEventIndex(ArgumentMultimap argMultimap) throws ParseException {
+        Index eventIndex;
+        try {
+            eventIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_EVENT_INDEX).get());
+        } catch (ParseException e) {
+            throw new ParseException("The Event Index is not a non-zero unsigned integer.");
+        }
+        return eventIndex;
+    }
+
+    private static boolean areNecessaryPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix compulsoryPrefix,
+                                                       Prefix... prefixes) {
+        return argumentMultimap.getValue(compulsoryPrefix).isPresent() &&
+                Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/event/parser/AddPersonToEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/parser/AddPersonToEventParser.java
@@ -1,34 +1,56 @@
 package seedu.address.logic.parser.event.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTENDEE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EVENT_INDEX;
-
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPONSOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VENDOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_VOLUNTEER;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.AddPersonToEventCommand;
-import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.CliSyntax;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * Parses input arguments and creates a new AddPersonToEventCommand object
+ */
 public class AddPersonToEventParser implements Parser<AddPersonToEventCommand> {
+    /**
+     * Parses the given arguments string and creates an {@code AddPersonToEventCommand}.
+     *
+     * <p>The method tokenizes the input string into its constituent parts using specified prefixes.
+     * It checks for the presence of required prefixes and validates that no unnecessary prefixes
+     * are present. If any validation fails, a {@code ParseException} is thrown.</p>
+     *
+     * <p>This method extracts the event index and sets of attendees, volunteers, vendors,
+     * and sponsors based on the parsed input.</p>
+     *
+     * @param args The input string containing the command arguments, which must include
+     *             the necessary prefixes for event index, attendees, volunteers, vendors,
+     *             and sponsors.
+     *
+     * @return An instance of {@code AddPersonToEventCommand} constructed from the parsed
+     *         indices and sets.
+     *
+     * @throws ParseException If any of the following conditions are met:
+     *         <ul>
+     *         <li>Required prefixes are missing from the input.</li>
+     *         <li>The input string contains extra characters that do not correspond to
+     *             recognized prefixes.</li>
+     *         <li>There are duplicate prefixes present in the input.</li>
+     *         <li>Invalid indices are provided for attendees, volunteers, vendors, or
+     *             sponsors.</li>
+     *         </ul>
+     */
     public AddPersonToEventCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_EVENT_INDEX, PREFIX_ATTENDEE, PREFIX_VOLUNTEER, PREFIX_SPONSOR, PREFIX_VENDOR);
@@ -52,13 +74,14 @@ public class AddPersonToEventParser implements Parser<AddPersonToEventCommand> {
         ParserUtil.parseStringOfIndices(attendees, argMultimap.getValue(PREFIX_ATTENDEE).orElse(null));
         ParserUtil.parseStringOfIndices(volunteers, argMultimap.getValue(PREFIX_VOLUNTEER).orElse(null));
         ParserUtil.parseStringOfIndices(vendors, argMultimap.getValue(PREFIX_VENDOR).orElse(null));
-        ParserUtil.parseStringOfIndices(sponsors,argMultimap.getValue(PREFIX_SPONSOR).orElse(null));
+        ParserUtil.parseStringOfIndices(sponsors, argMultimap.getValue(PREFIX_SPONSOR).orElse(null));
 
         return new AddPersonToEventCommand(eventIndex, attendees, volunteers, vendors, sponsors);
     }
 
     private static Index getEventIndex(ArgumentMultimap argMultimap) throws ParseException {
         Index eventIndex;
+
         try {
             eventIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_EVENT_INDEX).get());
         } catch (ParseException e) {
@@ -69,8 +92,9 @@ public class AddPersonToEventParser implements Parser<AddPersonToEventCommand> {
 
     private static boolean areNecessaryPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix compulsoryPrefix,
                                                        Prefix... prefixes) {
-        return argumentMultimap.getValue(compulsoryPrefix).isPresent() &&
-                Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        boolean a = argumentMultimap.getValue(compulsoryPrefix).isPresent();
+        return argumentMultimap.getValue(compulsoryPrefix).isPresent()
+                && Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/event/parser/NewEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/parser/NewEventCommandParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.event.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
@@ -6,6 +6,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import seedu.address.logic.commands.event.commands.AddEventCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Event;
 

--- a/src/main/java/seedu/address/logic/parser/event/parser/RemovePersonFromEventParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/parser/RemovePersonFromEventParser.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.event.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
@@ -7,6 +7,11 @@ import java.util.NoSuchElementException;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.CliSyntax;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -163,7 +163,9 @@ public class Event {
         try {
             Role personRole = RoleHandler.getRole(role);
             if (!person.hasRole(personRole)) {
-                throw new IllegalValueException("Person does not have the role " + role);
+                throw new IllegalValueException("One or more person(s) to be added does not have the " + role
+                        + " role that you are adding him or her to. For example, to add a person as an attendee of "
+                        + "Event X, make sure he or she has the attendee role.");
             }
             Set<Person> roleSet;
             switch (personRole.getRoleName()) {
@@ -183,14 +185,14 @@ public class Event {
                 throw new InvalidRoleException();
             }
             if (roleSet.contains(person)) {
-                throw new IllegalValueException("Person already has role in event: " + this.name);
+                throw new IllegalValueException("Contact " + person.getName() + " already has role in event: "
+                        + this.name);
             }
             roleSet.add(person);
         } catch (InvalidRoleException e) {
             throw new IllegalValueException(e.getMessage());
         }
     }
-
 
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -67,7 +67,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandException(deleteCommand, MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandIntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.contact.commands.AddCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandIntegrationTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.contact.commands.AddCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandTest.java
@@ -18,7 +18,6 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.contact.commands.AddCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -88,9 +87,6 @@ public class AddCommandTest {
         assertEquals(expected, addCommand.toString());
     }
 
-    /**
-     * A default model stub that have all of the methods failing.
-     */
     private class ModelStub implements Model {
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {

--- a/src/test/java/seedu/address/logic/commands/contact/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/ClearCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/ClearCommandTest.java
@@ -6,7 +6,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.contact.commands.ClearCommand;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/DeleteCommandTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.contact.commands.DeleteCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/DeleteCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -48,7 +48,7 @@ public class DeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class DeleteCommandTest {
 
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/contact/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/EditCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -168,7 +168,7 @@ public class EditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     /**
@@ -185,7 +185,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/contact/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/EditCommandTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.contact.commands.ClearCommand;
-import seedu.address.logic.commands.contact.commands.EditCommand;
 import seedu.address.logic.commands.contact.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/EditPersonDescriptorTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/FindCommandTest.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.contact.commands.FindCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/FindCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/ListCommandTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.contact.commands.ListCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/ListCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/SearchCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.contact.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/seedu/address/logic/commands/contact/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/SearchCommandTest.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.contact.commands.SearchCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/event/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/AddEventCommandTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.event.commands.AddEventCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ModelManager;
 import seedu.address.model.event.Event;

--- a/src/test/java/seedu/address/logic/commands/event/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/AddEventCommandTest.java
@@ -1,13 +1,15 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.event.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.event.commands.AddEventCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ModelManager;
@@ -41,7 +43,7 @@ public class AddEventCommandTest {
     @Test
     public void execute_newEvent_success() throws CommandException {
         EventManagerStubWithoutEvent eventManagerStubWithoutEvent = new EventManagerStubWithoutEvent();
-        assertEquals(new CommandResult(String.format("New event added: %1$s", "Festival")),
+        Assertions.assertEquals(new CommandResult(String.format("New event added: %1$s", "Festival")),
                 addEventCommand.execute(new ModelManager(), eventManagerStubWithoutEvent));
         assertTrue(eventManagerStubWithoutEvent.getIsAddEventCalled());
     }

--- a/src/test/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommandTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands.event.commands;
+
+public class AddPersonToEventCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommandTest.java
@@ -1,4 +1,188 @@
 package seedu.address.logic.commands.event.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalEvents.ART_EXHIBITION;
+import static seedu.address.testutil.TypicalEvents.TECH_CONFERENCE;
+import static seedu.address.testutil.TypicalEvents.TEST_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventManager;
+import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.EventBuilder;
+
 public class AddPersonToEventCommandTest {
+    private Model model;
+    private EventManager eventManager;
+    private HashSet<Index> attendees;
+    private HashSet<Index> volunteers;
+    private HashSet<Index> vendors;
+    private HashSet<Index> sponsors;
+
+    @BeforeEach
+    void setup() {
+        this.attendees = new HashSet<>();
+        this.volunteers = new HashSet<>();
+        this.vendors = new HashSet<>();
+        this.sponsors = new HashSet<>();
+
+        ReadOnlyAddressBook readOnlyAddressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON)
+                .withPerson(DANIEL).withPerson(ELLE).build();
+        EventManager eventManager = new EventManager();
+        eventManager.addEvent(TECH_CONFERENCE);
+        eventManager.addEvent(ART_EXHIBITION);
+        eventManager.addEvent(new EventBuilder().withName("Test Event").build());
+
+        this.model = new ModelManager(readOnlyAddressBook, eventManager, new UserPrefs());
+        this.eventManager = eventManager;
+    }
+    @Test
+    public void constructor_nullField_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddPersonToEventCommand(null, null,
+                null, null, null));
+    }
+
+    @Test
+    public void execute_nullField_throwsNullPointerException() {
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(0),
+                attendees, volunteers, vendors, sponsors);
+        assertThrows(NullPointerException.class, () -> addPersonToEventCommand.execute(null,
+                null));
+    }
+
+    @Test
+    public void execute_invalidContactIndex_throwsCommandException() {
+        attendees.add(INDEX_FIRST_PERSON);
+        sponsors.add(Index.fromZeroBased(4)); //invalid index
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(0),
+                attendees, volunteers, vendors, sponsors);
+        assertThrows(CommandException.class, () -> addPersonToEventCommand.execute(this.model,
+                this.eventManager));
+    }
+
+    @Test
+    public void execute_invalidEventIndex_throwsCommandException() {
+        attendees.add(INDEX_FIRST_PERSON);
+        sponsors.add(Index.fromZeroBased(0));
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2), //invalid index
+                attendees, volunteers, vendors, sponsors);
+        assertThrows(CommandException.class, () -> addPersonToEventCommand.execute(this.model,
+                this.eventManager));
+    }
+
+    @Test
+    public void execute_correctInputs_contactsAddedToEventSuccessfully() throws CommandException {
+        attendees.add(Index.fromZeroBased(0));
+        volunteers.add(Index.fromZeroBased(3));
+        vendors.add(Index.fromZeroBased(2));
+        sponsors.add(Index.fromZeroBased(1));
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2),
+                attendees, volunteers, vendors, sponsors);
+        Event expectedEvent = TEST_EVENT;
+        addPersonToEventCommand.execute(this.model, this.eventManager);
+        Event actualEvent = this.eventManager.getEventList().get(2);
+        assertEquals(expectedEvent, actualEvent);
+    }
+
+    @Test
+    public void execute_incorrectRoleOfContactAdded_throwsCommandException() {
+        volunteers.add(Index.fromZeroBased(0));
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2),
+                attendees, volunteers, vendors, sponsors);
+
+        assertThrows(CommandException.class, () -> addPersonToEventCommand.execute(this.model,
+                this.eventManager));
+    }
+
+    @Test
+    public void execute_duplicateContactAddedToSameRole_throwsCommandException() {
+        attendees.add(Index.fromZeroBased(0));
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(0),
+                attendees, volunteers, vendors, sponsors);
+
+        assertThrows(CommandException.class, () -> addPersonToEventCommand.execute(this.model,
+                this.eventManager));
+    }
+
+    @Test
+    public void execute_correctInputs_correctCommandResultMsg() throws CommandException {
+        vendors.add(Index.fromZeroBased(2));
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2),
+                attendees, volunteers, vendors, sponsors);
+
+        CommandResult expectedResult = new CommandResult("Contacts added to Test Event successfully: \n"
+                + "Vendor(s): Daniel Meier");
+        CommandResult actualResult = addPersonToEventCommand.execute(this.model, this.eventManager);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testToString() {
+        vendors.add(Index.fromZeroBased(2));
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2),
+                attendees, volunteers, vendors, sponsors);
+
+        String expectedString = "seedu.address.logic.commands.event.commands.AddPersonToEventCommand{eventIndex="
+                + "seedu.address.commons.core.index.Index{zeroBasedIndex=2}, attendees=[], volunteers=[], vendors="
+                + "[seedu.address.commons.core.index.Index{zeroBasedIndex=2}], sponsors=[]}";
+        String actualString = addPersonToEventCommand.toString();
+
+        assertEquals(expectedString, actualString);
+    }
+
+    @Test
+    public void testEquals() {
+        vendors.add(Index.fromZeroBased(2));
+
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2),
+                attendees, volunteers, vendors, sponsors);
+
+        AddPersonToEventCommand anotherAddPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2),
+                attendees, volunteers, vendors, sponsors);
+
+        AddPersonToEventCommand differentAddPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(0),
+                attendees, volunteers, vendors, sponsors);
+
+        assertTrue(addPersonToEventCommand.equals(addPersonToEventCommand));
+        assertTrue(addPersonToEventCommand.equals(anotherAddPersonToEventCommand));
+        assertFalse(addPersonToEventCommand.equals(differentAddPersonToEventCommand));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.event.commands;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommandTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Event;
 import seedu.address.model.person.Address;
@@ -278,5 +279,63 @@ public class ParserUtilTest {
         assertThrows(NullPointerException.class, () -> {
             ParserUtil.parseEvent(null);
         });
+    }
+
+    @Test
+    public void parseStringOfIndices_null_doesNothing() throws ParseException {
+        HashSet<Index> indices = new HashSet<>();
+        ParserUtil.parseStringOfIndices(indices, null);
+        assertEquals(indices, new HashSet<Index>());
+    }
+
+    @Test
+    public void parseStringOfIndices_invalidIndex_throwsParseException() throws ParseException {
+        HashSet<Index> indices = new HashSet<>();
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseStringOfIndices(indices, "0"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseStringOfIndices(indices, "-1"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseStringOfIndices(indices, "baby"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseStringOfIndices(indices, "10.5, 2, tree"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseStringOfIndices(indices, ""));
+        assertThrows(ParseException.class, () -> ParserUtil.parseStringOfIndices(indices, "1, "));
+    }
+
+    @Test
+    public void parseStringOfIndices_inputWithWhiteSpace_parsedSuccessfully() throws ParseException {
+        HashSet<Index> indices = new HashSet<>();
+        HashSet<Index> expectedIndices = new HashSet<>();
+
+        expectedIndices.add(Index.fromOneBased(1));
+        expectedIndices.add(Index.fromZeroBased(2));
+        expectedIndices.add(Index.fromZeroBased(1));
+        expectedIndices.add(Index.fromZeroBased(3));
+        expectedIndices.add(Index.fromZeroBased(4));
+        expectedIndices.add(Index.fromZeroBased(6));
+        expectedIndices.add(Index.fromZeroBased(8));
+
+        ParserUtil.parseStringOfIndices(indices, "  1,  3  ");
+        ParserUtil.parseStringOfIndices(indices, "2,  4  ,5,7  ,  9");
+
+        assertEquals(indices, expectedIndices);
+    }
+
+    @Test
+    public void parseStringOfIndices_inputWithoutWhiteSpace_parsedSuccessfully() throws ParseException {
+        HashSet<Index> indices = new HashSet<>();
+        HashSet<Index> expectedIndices = new HashSet<>();
+
+        expectedIndices.add(Index.fromOneBased(1));
+        expectedIndices.add(Index.fromZeroBased(2));
+
+        ParserUtil.parseStringOfIndices(indices, "1,3");
+
+        assertEquals(indices, expectedIndices);
+    }
+
+    @Test
+    public void parseStringOfIndices_duplicateIndices_throwsParseException() {
+        HashSet<Index> indices = new HashSet<>();
+
+        assertThrows(ParseException.class, () -> ParserUtil.parseStringOfIndices(indices, "1,1"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/contact/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/AddCommandParserTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.contact.commands.AddCommand;
-import seedu.address.logic.parser.contact.parser.AddCommandParser;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;

--- a/src/test/java/seedu/address/logic/parser/contact/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/AddCommandParserTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.contact.commands.AddCommand;
+import seedu.address.logic.parser.contact.parser.AddCommandParser;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;

--- a/src/test/java/seedu/address/logic/parser/contact/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/DeleteCommandParserTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.contact.commands.DeleteCommand;
+import seedu.address.logic.parser.contact.parser.DeleteCommandParser;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/seedu/address/logic/parser/contact/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/DeleteCommandParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.contact.commands.DeleteCommand;
-import seedu.address.logic.parser.contact.parser.DeleteCommandParser;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations

--- a/src/test/java/seedu/address/logic/parser/contact/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/EditCommandParserTest.java
@@ -32,7 +32,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.contact.commands.EditCommand;
 import seedu.address.logic.commands.contact.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.parser.contact.parser.EditCommandParser;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;

--- a/src/test/java/seedu/address/logic/parser/contact/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/EditCommandParserTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -32,6 +32,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.contact.commands.EditCommand;
 import seedu.address.logic.commands.contact.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.parser.contact.parser.EditCommandParser;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;

--- a/src/test/java/seedu/address/logic/parser/contact/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/FindCommandParserTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.contact.commands.FindCommand;
+import seedu.address.logic.parser.contact.parser.FindCommandParser;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/contact/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/FindCommandParserTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.contact.commands.FindCommand;
-import seedu.address.logic.parser.contact.parser.FindCommandParser;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/contact/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/SearchCommandParserTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.contact.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.contact.commands.SearchCommand;
+import seedu.address.logic.parser.contact.parser.SearchCommandParser;
 import seedu.address.model.person.PersonIsRolePredicate;
 import seedu.address.model.role.Sponsor;
 import seedu.address.model.role.Volunteer;

--- a/src/test/java/seedu/address/logic/parser/contact/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/contact/parser/SearchCommandParserTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.contact.commands.SearchCommand;
-import seedu.address.logic.parser.contact.parser.SearchCommandParser;
 import seedu.address.model.person.PersonIsRolePredicate;
 import seedu.address.model.role.Sponsor;
 import seedu.address.model.role.Volunteer;

--- a/src/test/java/seedu/address/logic/parser/event/parser/AddPersonToEventParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/AddPersonToEventParserTest.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.parser.event.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.commands.AddPersonToEventCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class AddPersonToEventParserTest {
+    @Test
+    public void parse_compulsoryPrefixAbsent_throwsParseException() {
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" a/1,2"));
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(""));
+    }
+
+    @Test
+    public void parse_allRolePrefixesAbsent_throwsParseException() {
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" ei/1"));
+    }
+
+    @Test
+    public void parse_nonEmptyPreamble_throwsParseException() {
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" hello ei/1"));
+    }
+
+    @Test
+    public void parse_duplicatePrefixes_throwsParseException() {
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" ei/1 a/1 a/2"));
+    }
+
+    @Test
+    public void parse_invalidIndices_throwsParseException() {
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" ei/0 a/1"));
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" ei/0 ve/2"));
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" ei/1 s/apple"));
+        assertThrows(ParseException.class, () -> new AddPersonToEventParser().parse(" ei/100 ve/1 vo/-3"));
+    }
+
+    @Test
+    public void parse_correctInputs_success() throws ParseException {
+        HashSet<Index> attendees = new HashSet<>();
+        HashSet<Index> volunteers = new HashSet<>();
+        HashSet<Index> vendors = new HashSet<>();
+        HashSet<Index> sponsors = new HashSet<>();
+        attendees.add(Index.fromZeroBased(0));
+        vendors.add(Index.fromZeroBased(1));
+        AddPersonToEventCommand expectedAddPersonToEventCommand = new AddPersonToEventCommand(Index.fromZeroBased(0),
+                attendees, volunteers, vendors, sponsors);
+
+        AddPersonToEventCommand actualAddPersonToEventCommand = new AddPersonToEventParser()
+                .parse(" ei/1 ve/2 a/1");
+
+        assertEquals(expectedAddPersonToEventCommand, actualAddPersonToEventCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/event/parser/NewEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/NewEventCommandParserTest.java
@@ -6,7 +6,6 @@ import static seedu.address.testutil.Assert.assertThrows;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.event.commands.AddEventCommand;
-import seedu.address.logic.parser.event.parser.NewEventCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Event;
 

--- a/src/test/java/seedu/address/logic/parser/event/parser/NewEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/NewEventCommandParserTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.event.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -6,6 +6,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.event.commands.AddEventCommand;
+import seedu.address.logic.parser.event.parser.NewEventCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.Event;
 

--- a/src/test/java/seedu/address/logic/parser/event/parser/RemovePersonFromEventParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/RemovePersonFromEventParserTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.event.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
+import seedu.address.logic.parser.event.parser.RemovePersonFromEventParser;
 
 
 public class RemovePersonFromEventParserTest {

--- a/src/test/java/seedu/address/logic/parser/event/parser/RemovePersonFromEventParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/RemovePersonFromEventParserTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
-import seedu.address.logic.parser.event.parser.RemovePersonFromEventParser;
 
 
 public class RemovePersonFromEventParserTest {

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -52,6 +52,7 @@ public class TypicalEvents {
             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
             .build();
 
+
     private TypicalEvents() {} // prevents instantiation
 
     /**


### PR DESCRIPTION
closes #107 

Implemented adding of contacts to events with `event-add ei/EVENT INDEX [a/ | s/ | ve/ | vo/]CONTACT INDEX` where event index is compulsory and one of a/ or s/ or ve/ or vo/ prefixes followed by at least one contact index is compulsory. 
e.g. `event-add ei/1 a/1,2 ve/3`

Duplicate indices for the same role is not allowed e.g. `event-add ei/1 a/1,1`, but is allowed for different roles e.g. `event-add ei/1 a/1 ve/1` provided that the contact added has the role that he or she is being added to.

TODO:
update UI to be able to dynamically render the changes to number of attendees etc on adding of contacts.