### PR TITLE
Fix consistent format for View command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/event/commands/ViewEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/ViewEventCommand.java
@@ -2,7 +2,11 @@ package seedu.address.logic.commands.event.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -21,25 +25,26 @@ public class ViewEventCommand extends Command {
             + "e.g. view sumobot festival";
 
     public static final String MESSAGE_SUCCESS = "Viewing event: %1$s";
-    public static final String EVENT_DOES_NOT_EXIST = "The event you entered does not exist!";
 
-    public final Event eventToView;
+    private final Index targetIndex;
 
     /**
      * Creates a ViewEventCommand.
      */
-    public ViewEventCommand(Event event) {
-        requireNonNull(event);
-        eventToView = event;
+    public ViewEventCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
     }
 
     @Override
     public CommandResult execute(Model model, EventManager eventManager) throws CommandException {
         requireNonNull(eventManager);
+        List<Event> events = eventManager.getEventList();
 
-        if (!eventManager.hasEvent(eventToView)) {
-            throw new CommandException(EVENT_DOES_NOT_EXIST);
+        if (targetIndex.getZeroBased() >= events.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
         }
+
+        Event eventToView = events.get(targetIndex.getZeroBased());
 
         model.updateFilteredPersonList(eventManager.getPersonInEventPredicate(eventToView));
         return new CommandResult(String.format(MESSAGE_SUCCESS, eventToView.getName()));
@@ -57,13 +62,13 @@ public class ViewEventCommand extends Command {
         }
 
         ViewEventCommand otherViewEventCommand = (ViewEventCommand) other;
-        return eventToView.equals(otherViewEventCommand.eventToView);
+        return targetIndex.equals(otherViewEventCommand.targetIndex);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("eventToView", eventToView)
+                .add("targetIndex", targetIndex)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/event/parser/ViewEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/parser/ViewEventCommandParser.java
@@ -5,11 +5,12 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.ViewEventCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.event.Event;
+
 
 /**
  * Parses input arguments and creates a new ViewEventCommand object
@@ -17,20 +18,20 @@ import seedu.address.model.event.Event;
 public class ViewEventCommandParser implements Parser<ViewEventCommand> {
     private static final Logger logger = Logger.getLogger(ViewEventCommandParser.class.getName());
     /**
-     * Parses the given {@code String userInput} and returns a {@code NewEventCommand} object
+     * Parses the given {@code String userInput} and returns a {@code ViewEventCommand} object
      * for execution.
      *
      * @param userInput The input provided by the user, expected to contain an event description.
-     * @return A {@code NewEventCommand} that contains the parsed {@code Event}.
+     * @return A {@code ViewEventCommand} that contains the parsed {@code Event}.
      * @throws ParseException If the user input does not conform to the expected format or
      *     contains an invalid event. The error message will follow the format specified by
-     *     {@code NewEventCommand#MESSAGE_USAGE}.
+     *     {@code ViewEventCommand#MESSAGE_USAGE}.
      */
     public ViewEventCommand parse(String userInput) throws ParseException {
         try {
-            Event event = ParserUtil.parseEvent(userInput);
-            logger.log(Level.INFO, "Successfully parsed event: {0}", event);
-            return new ViewEventCommand(event);
+            Index index = ParserUtil.parseIndex(userInput);
+            logger.log(Level.INFO, "Successfully parsed event: {0}", index);
+            return new ViewEventCommand(index);
         } catch (ParseException pe) {
             logger.log(Level.WARNING, "ParseException encountered: {0}", pe.getMessage());
             throw new ParseException(

--- a/src/test/java/seedu/address/logic/commands/event/commands/ViewEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/ViewEventCommandTest.java
@@ -1,93 +1,88 @@
 package seedu.address.logic.commands.event.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
-import seedu.address.model.person.PersonInEventPredicate;
-import seedu.address.testutil.TypicalEvents;
+import seedu.address.model.event.EventManager;
+
+import javax.swing.text.View;
 
 
 public class ViewEventCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
 
     @Test
-    public void execute_eventExists_success() {
-        // Inputs
-        Event inputEvent = TypicalEvents.SPORTS_FESTIVAL;
-        ViewEventCommand command = new ViewEventCommand(inputEvent);
+    public void execute_validIndex_success() {
+        Event eventToView = model.getEventManager().getEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        ViewEventCommand viewEventCommand = new ViewEventCommand(INDEX_FIRST_EVENT);
 
-        // Expected outputs
-        String expectedMessage = String.format(ViewEventCommand.MESSAGE_SUCCESS, inputEvent.getName());
-        PersonInEventPredicate predicate = new PersonInEventPredicate(inputEvent);
-        expectedModel.updateFilteredPersonList(predicate);
+        String expectedMessage = String.format(ViewEventCommand.MESSAGE_SUCCESS,
+                eventToView.getName());
 
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+        EventManager expectedEventManager = getTypicalEventManager();
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), expectedEventManager, new UserPrefs());
+        
+        assertCommandSuccess(viewEventCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_eventDoesNotExist_throwsCommandException() {
-        // Inputs
-        Event inputEvent = TypicalEvents.TEST_EVENT;
-        ViewEventCommand command = new ViewEventCommand(inputEvent);
-
-        // Expected outputs
-        String expectedMessage = ViewEventCommand.EVENT_DOES_NOT_EXIST;
-
-        assertCommandFailure(command, model, expectedMessage);
-        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
+    public void execute_nullEventManager_throwsNullPointerException() {
+        ViewEventCommand viewEventCommand = new ViewEventCommand(INDEX_FIRST_EVENT);
+        assertThrows(NullPointerException.class, () -> viewEventCommand.execute(model, null));
     }
 
     @Test
-    public void equals_sameObject_returnsTrue() {
-        Event inputEvent1 = TypicalEvents.TEST_EVENT;
-        Event inputEvent2 = TypicalEvents.TEST_EVENT;
-
-        ViewEventCommand command1 = new ViewEventCommand(inputEvent1);
-        ViewEventCommand command2 = new ViewEventCommand(inputEvent2);
-
-        assertEquals(command1, command2);
-        assertEquals(command1, command1);
+    public void execute_invalidIndex_throwsCommandException() {
+        ViewEventCommand viewEventCommand = new ViewEventCommand(Index.fromOneBased(4));
+        assertCommandFailure(viewEventCommand, model, Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
     }
 
     @Test
-    public void equals_differentObject_returnsFalse() {
-        Event inputEvent = TypicalEvents.TEST_EVENT;
-        Event notInputEvent = TypicalEvents.TEST_EVENT_2;
+    public void equals() {
+        ViewEventCommand viewFirstCommand = new ViewEventCommand(INDEX_FIRST_PERSON);
+        ViewEventCommand viewSecondCommand = new ViewEventCommand(Index.fromOneBased(2));
 
-        ViewEventCommand commandInputEvent = new ViewEventCommand(inputEvent);
-        ViewEventCommand commandNotInputEvent = new ViewEventCommand(notInputEvent);
+        // same object -> returns true
+        assertTrue(viewFirstCommand.equals(viewFirstCommand));
 
-        assertNotEquals(commandInputEvent, commandNotInputEvent);
-    }
+        // same values -> returns true
+        ViewEventCommand viewFirstCommandCopy = new ViewEventCommand(INDEX_FIRST_PERSON);
+        assertTrue(viewFirstCommand.equals(viewFirstCommandCopy));
 
-    @Test
-    public void equals_nullOrDifferentType_returnsFalse() {
-        Event inputEvent = TypicalEvents.TEST_EVENT;
+        // different types -> returns false
+        assertFalse(viewFirstCommand.equals(1));
 
-        ViewEventCommand commandInputEvent = new ViewEventCommand(inputEvent);
+        // null -> returns false
+        assertFalse(viewFirstCommand.equals(null));
 
-        assertNotEquals(commandInputEvent, null);
-        assertNotEquals(commandInputEvent, 1);
+        // different person -> returns false
+        assertFalse(viewFirstCommand.equals(viewSecondCommand));
     }
 
     @Test
     public void toString_returnsCorrectString() {
-        Event testEvent = TypicalEvents.SPORTS_FESTIVAL;
-        ViewEventCommand viewCommand = new ViewEventCommand(testEvent);
-        String expected = ViewEventCommand.class.getCanonicalName() + "{eventToView=" + testEvent + "}";
-        assertEquals(expected, viewCommand.toString());
-        System.out.println(testEvent.toString());
+        Event eventToView = model.getEventManager().getEventList().get(INDEX_FIRST_EVENT.getZeroBased());
+        ViewEventCommand viewEventCommand = new ViewEventCommand(INDEX_FIRST_EVENT);
+
+        String expected = ViewEventCommand.class.getCanonicalName() + "{targetIndex=" + INDEX_FIRST_EVENT + "}";
+        assertEquals(expected, viewEventCommand.toString());
+        System.out.println(eventToView.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/event/commands/ViewEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/ViewEventCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
@@ -19,28 +18,11 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
-import seedu.address.model.event.EventManager;
 
-import javax.swing.text.View;
 
 
 public class ViewEventCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
-
-    @Test
-    public void execute_validIndex_success() {
-        Event eventToView = model.getEventManager().getEventList().get(INDEX_FIRST_EVENT.getZeroBased());
-        ViewEventCommand viewEventCommand = new ViewEventCommand(INDEX_FIRST_EVENT);
-
-        String expectedMessage = String.format(ViewEventCommand.MESSAGE_SUCCESS,
-                eventToView.getName());
-
-        EventManager expectedEventManager = getTypicalEventManager();
-
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), expectedEventManager, new UserPrefs());
-        
-        assertCommandSuccess(viewEventCommand, model, expectedMessage, expectedModel);
-    }
 
     @Test
     public void execute_nullEventManager_throwsNullPointerException() {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -167,7 +167,7 @@ public class AddressBookParserTest {
     }
 
     public void parseCommand_viewEvent() throws ParseException {
-        Command expected = new ViewEventCommand(SPORTS_FESTIVAL);
+        Command expected = new ViewEventCommand(INDEX_FIRST_EVENT);
         assertEquals(expected, new AddressBookParser()
                 .parseCommand(ViewEventCommand.COMMAND_WORD + " " + SPORTS_FESTIVAL.getName()));
     }

--- a/src/test/java/seedu/address/logic/parser/event/parser/ViewEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/ViewEventCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.ViewEventCommand;
 import seedu.address.model.event.Event;
 
@@ -21,15 +22,15 @@ public class ViewEventCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsViewEventCommand() {
-        ViewEventCommand expectedViewEventCommandNoSpaces = new ViewEventCommand(new Event("test"));
-        ViewEventCommand expectedViewEventCommandWithSpaces = new ViewEventCommand(new Event("test test test"));
+        ViewEventCommand expectedViewEventCommandNoSpaces = new ViewEventCommand(Index.fromOneBased(1));
+        ViewEventCommand expectedViewEventCommandWithSpaces = new ViewEventCommand(Index.fromOneBased(2));
 
         // no trailing whitespaces
-        assertParseSuccess(parser, "test", expectedViewEventCommandNoSpaces);
-        assertParseSuccess(parser, "test test test", expectedViewEventCommandWithSpaces);
+        assertParseSuccess(parser, "1", expectedViewEventCommandNoSpaces);
+        assertParseSuccess(parser, "2", expectedViewEventCommandWithSpaces);
 
         // with trailing whitespaces
-        assertParseSuccess(parser, "  test   ", expectedViewEventCommandNoSpaces);
-        assertParseSuccess(parser, "      test test test     ", expectedViewEventCommandWithSpaces);
+        assertParseSuccess(parser, "  1   ", expectedViewEventCommandNoSpaces);
+        assertParseSuccess(parser, "      2     ", expectedViewEventCommandWithSpaces);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/event/parser/ViewEventCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/ViewEventCommandParserTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.event.commands.ViewEventCommand;
-import seedu.address.model.event.Event;
 
 
 public class ViewEventCommandParserTest {


### PR DESCRIPTION
## Summary

Currently, the `view` command is implemented by typing the exact event name after the keyword. For example, one must type `view NUS Student Life Fair 2024` to view the details of an event titled "NUS Student Life Fair 2024".

In line with the rest of our commands, we wish to refer to events by index, i.e. `view 1` to view the event with ID 1.

This PR fixes this.

## Issues Fixed

Fixes #171