### PR TITLE
Remove displaying of optional empty fields when editing Person

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -49,16 +49,23 @@ public class Messages {
                 .append(person.getAddress());
 
         appendTelegramUsernameToMsg(person, builder);
-        builder.append("; Roles: ");
-        person.getRoles().forEach(builder::append);
+
+        appendRolesToMsg(person, builder);
 
         return builder.toString();
     }
 
     private static void appendTelegramUsernameToMsg(Person person, StringBuilder builder) {
-        builder.append("; Telegram username: ");
         if (person.getTelegramUsername().toString() != null) {
+            builder.append("; Telegram username: ");
             builder.append(person.getTelegramUsername());
+        }
+    }
+
+    private static void appendRolesToMsg(Person person, StringBuilder builder) {
+        if (!person.getRoles().isEmpty()) {
+            builder.append("; Roles: ");
+            person.getRoles().forEach(builder::append);
         }
     }
 


### PR DESCRIPTION
## Summary

When a person is edited, the optional fields are shown, even when they are left out.

![image](https://github.com/user-attachments/assets/e4cc3639-01d1-437b-8aab-6d662b5fc999)


This PR fixes the issue.

## Issues Fixed

Closes #166 