### PR TITLE
Update Event Card UI to become reactive to contact changes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/contact/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/DeleteCommand.java
@@ -46,6 +46,7 @@ public class DeleteCommand extends Command {
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
         eventManager.removeAllPersonsInEvents(personToDelete);
+        eventManager.updateEvents();
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
@@ -21,12 +21,12 @@ import seedu.address.model.person.Person;
  * Adds contacts to an event in to the address book.
  */
 public class AddPersonToEventCommand extends Command {
-    public static final String COMMAND_WORD = "event-add";
+    public static final String COMMAND_WORD = "eventadd";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " ei/EVENT INDEX [a/ or s/ or ve/ or vo/] CONTACT "
             + "INDEX \nAdds contacts to an event in the address book. \nNote: At least one of the following prefixes "
             + "is required—`a/`, `e/`, `ve/`, or `vo/`—each followed by one or more contact index/indices \ne.g. "
-            + "event-add ei/1 a/1,2,3";
+            + "eventadd ei/1 a/1,2,3";
 
     public static final String MESSAGE_SUCCESS = "Contacts added to %2$s successfully: \n%1$s";
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
@@ -92,6 +92,7 @@ public class AddPersonToEventCommand extends Command {
         }
 
         sb.delete(sb.length() - 1, sb.length());
+        event.updateUi();
         return new CommandResult(String.format(MESSAGE_SUCCESS, sb, event.getName()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -75,6 +75,7 @@ public class RemovePersonFromEventCommand extends Command {
 
         event.removePerson(person, personRole);
         eventManager.setEvent(originalEvent, event);
+        event.updateUi();
         return new CommandResult(String.format(MESSAGE_SUCCESS, person.getName(), event.getName()));
 
 

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -351,4 +351,18 @@ public class Event {
         persons.addAll(sponsors);
         return persons.size();
     }
+
+    /**
+     * Retrieves the currently registered observer.
+     * <p>
+     * This method returns the observer that has been added to this object via the
+     * {@code addObserver(Observer observer)} method. If no observer has been registered,
+     * this method will return {@code null}.
+     * </p>
+     *
+     * @return The currently registered {@code Observer}, or {@code null} if no observer is set.
+     */
+    public Observer getObserver() {
+        return this.observer;
+    }
 }

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -307,10 +307,48 @@ public class Event {
                 || sponsors.contains(person) || vendors.contains(person);
     }
 
+    /**
+     * Registers an observer to this object.
+     * <p>
+     * Sets the specified {@code observer} as the observer of this object. The observer will be
+     * notified of changes by calling its {@code update()} method when {@code updateUi()} is invoked.
+     * Only one observer can be registered at a time; any previously registered observer will be replaced.
+     * </p>
+     *
+     * @param observer The observer to register, which will be notified of updates.
+     */
     public void addObserver(Observer observer) {
         this.observer = observer;
     }
+
+    /**
+     * Notifies the registered observer of a UI update.
+     * <p>
+     * If an observer is registered, this method calls the observer's {@code update()} method to
+     * reflect any necessary changes in the user interface. If no observer is registered, this method does nothing.
+     * </p>
+     */
     public void updateUi() {
-        this.observer.update();
+        if (this.observer != null) {
+            this.observer.update();
+        }
+    }
+
+    /**
+     * Returns the total number of distinct contacts involved in the event.
+     * <p>
+     * This method calculates the total number of unique {@code Person} objects across
+     * attendees, volunteers, vendors, and sponsors by combining them into a set to eliminate duplicates.
+     * </p>
+     *
+     * @return The count of distinct persons participating in the event.
+     */
+    public int getTotalNumberOfDistinctContacts() {
+        HashSet<Person> persons = new HashSet<>();
+        persons.addAll(attendees);
+        persons.addAll(volunteers);
+        persons.addAll(vendors);
+        persons.addAll(sponsors);
+        return persons.size();
     }
 }

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -11,6 +11,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.role.Role;
 import seedu.address.model.role.RoleHandler;
 import seedu.address.model.role.exceptions.InvalidRoleException;
+import seedu.address.ui.Observer;
 
 
 /**
@@ -23,6 +24,7 @@ public class Event {
     private final Set<Person> vendors;
     private final Set<Person> sponsors;
     private final Set<Person> volunteers;
+    private Observer observer;
 
     /**
      * Constructs a {@code Event}.
@@ -303,5 +305,12 @@ public class Event {
     public boolean isPersonInEvent(Person person) {
         return attendees.contains(person) || volunteers.contains(person)
                 || sponsors.contains(person) || vendors.contains(person);
+    }
+
+    public void addObserver(Observer observer) {
+        this.observer = observer;
+    }
+    public void updateUi() {
+        this.observer.update();
     }
 }

--- a/src/main/java/seedu/address/model/event/EventManager.java
+++ b/src/main/java/seedu/address/model/event/EventManager.java
@@ -150,4 +150,18 @@ public class EventManager implements ReadOnlyEventManager {
         EventManager otherEventManager = (EventManager) other;
         return eventList.equals(otherEventManager.eventList);
     }
+
+    /**
+     * Updates the UI for each event in the event list.
+     * <p>
+     * This method iterates over all events in the {@code eventList} and calls their
+     * {@code updateUi()} method, ensuring that any changes to event data are reflected
+     * in the user interface.
+     * </p>
+     */
+    public void updateEvents() {
+        for (Event event : this.eventList) {
+            event.updateUi();
+        }
+    }
 }

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.event.Event;
@@ -45,7 +44,7 @@ public class EventCard extends UiPart<Region> implements Observer {
     @FXML
     private Label volunteers;
     @FXML
-    private FlowPane roles;
+    private Label total;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -60,6 +59,7 @@ public class EventCard extends UiPart<Region> implements Observer {
         vendors.setText("Vendors: " + event.getVendors().size());
         sponsors.setText("Sponsors: " + event.getSponsors().size());
         volunteers.setText("Volunteers: " + event.getVolunteers().size());
+        total.setText("Total: " + event.getTotalNumberOfDistinctContacts());
     }
 
     @Override
@@ -68,5 +68,6 @@ public class EventCard extends UiPart<Region> implements Observer {
         vendors.setText("Vendors: " + event.getVendors().size());
         sponsors.setText("Sponsors: " + event.getSponsors().size());
         volunteers.setText("Volunteers: " + event.getVolunteers().size());
+        total.setText("Total: " + event.getTotalNumberOfDistinctContacts());
     }
 }

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -14,7 +14,7 @@ import seedu.address.model.event.Event;
 /**
  * An UI component that displays information of a {@code Person}.
  */
-public class EventCard extends UiPart<Region> {
+public class EventCard extends UiPart<Region> implements Observer {
 
     private static final String FXML = "EventListCard.fxml";
 
@@ -56,6 +56,14 @@ public class EventCard extends UiPart<Region> {
         this.event = event;
         id.setText(displayedIndex + ". ");
         name.setText(event.getName());
+        attendees.setText("Attendees: " + event.getAttendees().size());
+        vendors.setText("Vendors: " + event.getVendors().size());
+        sponsors.setText("Sponsors: " + event.getSponsors().size());
+        volunteers.setText("Volunteers: " + event.getVolunteers().size());
+    }
+
+    @Override
+    public void update() {
         attendees.setText("Attendees: " + event.getAttendees().size());
         vendors.setText("Vendors: " + event.getVendors().size());
         sponsors.setText("Sponsors: " + event.getSponsors().size());

--- a/src/main/java/seedu/address/ui/EventListPanel.java
+++ b/src/main/java/seedu/address/ui/EventListPanel.java
@@ -41,7 +41,9 @@ public class EventListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new EventCard(event, getIndex() + 1).getRoot());
+                EventCard eventCard = new EventCard(event, getIndex() + 1);
+                setGraphic(eventCard.getRoot());
+                event.addObserver(eventCard);
             }
         }
     }

--- a/src/main/java/seedu/address/ui/Observer.java
+++ b/src/main/java/seedu/address/ui/Observer.java
@@ -1,0 +1,5 @@
+package seedu.address.ui;
+
+public interface Observer {
+    public void update();
+}

--- a/src/main/java/seedu/address/ui/Observer.java
+++ b/src/main/java/seedu/address/ui/Observer.java
@@ -1,5 +1,22 @@
 package seedu.address.ui;
 
+/**
+ * Represents an observer in the observer design pattern.
+ * <p>
+ * Classes implementing this interface are notified of changes in observable subjects
+ * and can perform updates in response. The specific behavior of {@code update()} depends on
+ * the implementation, which may include refreshing UI elements, logging changes, or
+ * performing other relevant actions.
+ * </p>
+ */
 public interface Observer {
+    /**
+     * Updates the current state of this object.
+     * <p>
+     * This method performs any necessary actions to bring the object's state
+     * up-to-date, ensuring it reflects the latest data or changes. The exact
+     * behavior of this update depends on the implementing class.
+     * </p>
+     */
     public void update();
 }

--- a/src/main/resources/view/EventListCard.fxml
+++ b/src/main/resources/view/EventListCard.fxml
@@ -3,7 +3,6 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>

--- a/src/main/resources/view/EventListCard.fxml
+++ b/src/main/resources/view/EventListCard.fxml
@@ -28,10 +28,20 @@
                     <Label fx:id="name" text="\$first" styleClass="cell_big_label_event" />
                 </HBox>
             </HBox>
-            <Label fx:id="attendees" styleClass="cell_small_label_event" text="\$attendees" />
-            <Label fx:id="vendors" styleClass="cell_small_label_event" text="\$vendors" />
-            <Label fx:id="sponsors" styleClass="cell_small_label_event" text="\$sponsors" />
-            <Label fx:id="volunteers" styleClass="cell_small_label_event" text="\$volunteers" />
+            <HBox>
+                <VBox>
+                    <Label fx:id="attendees" styleClass="cell_small_label_event" text="\$attendees" />
+                    <Label fx:id="vendors" styleClass="cell_small_label_event" text="\$vendors" />
+                    <Label fx:id="sponsors" styleClass="cell_small_label_event" text="\$sponsors" />
+                    <Label fx:id="volunteers" styleClass="cell_small_label_event" text="\$volunteers" />
+                </VBox>
+                <VBox>
+                    <padding>
+                        <Insets top="5" right="0" bottom="0" left="135" />
+                    </padding>
+                    <Label fx:id="total" styleClass="cell_medium_label_event" text="\$total" />
+                </VBox>
+            </HBox>
         </VBox>
     </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -14,7 +14,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
-
+import seedu.address.testutil.TypicalEvents;
+import seedu.address.ui.Observer;
 
 
 public class EventTest {
@@ -303,5 +304,24 @@ public class EventTest {
         } catch (Exception e) {
             assert false;
         }
+    }
+
+    private class DummyObserver implements Observer {
+        public void update() {
+
+        }
+    }
+    @Test
+    public void testAddObserver() {
+        Observer dummyObserver = new DummyObserver();
+        Event dummyEvent = new Event("dummy");
+        dummyEvent.addObserver(dummyObserver);
+        assertEquals(dummyEvent.getObserver(), dummyObserver);
+    }
+
+    @Test
+    public void testGetTotalNumberOfDistinctContacts() {
+        Event event = TypicalEvents.getTypicalEvents().get(0);
+        assertEquals(event.getTotalNumberOfDistinctContacts(), 6);
     }
 }


### PR DESCRIPTION
Fixes #137 
Fixes #148 

1. Changed "event-add" to "eventadd" to become consistent with other command styles
2. Added an Observer pattern to have the UI be updated whenever contacts of an event changes
3. Added a total count to events to reflect total number of distinct contacts in events