### PR TITLE
Clear command box after user enters a command even if invalid

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -56,9 +56,10 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandBuffer.addCommand(commandText);
             commandExecutor.execute(commandText);
-            commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        } finally {
+            commandTextField.setText("");
         }
     }
 


### PR DESCRIPTION
## Overview

This PR changes the behaviour of the app such that when a user enters a valid or invalid command, the search box will clear.

The user can then use the up and down arrow keys to scroll through the command history.

## Issues Fixed

Closes #152 