### PR TITLE
Implement addall feature

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -54,16 +54,16 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command contactCommand;
+        Command command;
         if (model.getSearchMode()) {
             logger.info("Searchmode command detected");
-            contactCommand = addressBookParser.parseFindRoleCommand(commandText);
+            command = addressBookParser.parseFindRoleCommand(commandText);
 
         } else {
-            contactCommand = addressBookParser.parseCommand(commandText);
+            command = addressBookParser.parseCommand(commandText);
 
         }
-        commandResult = contactCommand.execute(model, eventManager);
+        commandResult = command.execute(model, eventManager);
 
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,6 +22,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_EMPTY_CONTACTS_ON_ADDALL = "There needs to be at least one contact in the "
+            + "search panel to add to the event";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
@@ -21,12 +21,12 @@ import seedu.address.model.person.Person;
  * Adds contacts to an event in to the address book.
  */
 public class AddPersonToEventCommand extends Command {
-    public static final String COMMAND_WORD = "eventadd";
+    public static final String COMMAND_WORD = "event-add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + " ei/EVENT INDEX [a/ or s/ or ve/ or vo/] CONTACT "
             + "INDEX \nAdds contacts to an event in the address book. \nNote: At least one of the following prefixes "
             + "is required—`a/`, `e/`, `ve/`, or `vo/`—each followed by one or more contact index/indices \ne.g. "
-            + "eventadd ei/1 a/1,2,3";
+            + "event-add ei/1 a/1,2,3";
 
     public static final String MESSAGE_SUCCESS = "Contacts added to %2$s successfully: \n%1$s";
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/EventAddAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/EventAddAllCommand.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands.event.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashSet;
+import java.util.List;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.event.Event;
+import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Person;
+import seedu.address.model.role.Attendee;
+import seedu.address.model.role.Sponsor;
+import seedu.address.model.role.Vendor;
+import seedu.address.model.role.Volunteer;
+
+/**
+ * Adds all contacts from searchmode to an event.
+ */
+public class EventAddAllCommand extends Command {
+    public static final String COMMAND_WORD = "add-all";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " EVENT INDEX: Adds contacts listed in searchmode "
+            + "to event. e.g. add-all 2";
+    private Index targetIndex;
+
+    public EventAddAllCommand(Index index) {
+        this.targetIndex = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model, EventManager eventManager) throws CommandException {
+        requireNonNull(eventManager);
+        List<Event> events = eventManager.getEventList();
+
+        if (targetIndex.getZeroBased() >= events.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
+        }
+
+        HashSet<Index> attendees = new HashSet<>();
+        HashSet<Index> volunteers = new HashSet<>();
+        HashSet<Index> vendors = new HashSet<>();
+        HashSet<Index> sponsors = new HashSet<>();
+        addContactsToEventRoles(model, attendees, volunteers, vendors, sponsors);
+        return new AddPersonToEventCommand(this.targetIndex, attendees, volunteers, vendors, sponsors)
+                .execute(model, eventManager);
+    }
+
+    private void addContactsToEventRoles(Model model, HashSet<Index> attendees, HashSet<Index> volunteers,
+                                         HashSet<Index> vendors, HashSet<Index> sponsors) throws CommandException {
+        ObservableList<Person> persons = model.getFilteredPersonList();
+        if (persons.isEmpty()) {
+            throw new CommandException(Messages.MESSAGE_EMPTY_CONTACTS_ON_ADDALL);
+        }
+        for (int i = 0; i < persons.size(); i++) {
+            Person person = persons.get(i);
+            Index indexToAdd = Index.fromZeroBased(i);
+            if (person.hasRole(new Attendee())) {
+                attendees.add(indexToAdd);
+            }
+            if (person.hasRole(new Volunteer())) {
+                volunteers.add(indexToAdd);
+            }
+            if (person.hasRole(new Vendor())) {
+                vendors.add(indexToAdd);
+            }
+            if (person.hasRole(new Sponsor())) {
+                sponsors.add(indexToAdd);
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EventAddAllCommand)) {
+            return false;
+        }
+
+        EventAddAllCommand otherEventAddAllCommand = (EventAddAllCommand) other;
+        return targetIndex.equals(otherEventAddAllCommand.targetIndex);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
@@ -24,7 +24,7 @@ public class FindEventCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + " EVENT NAME: View list of persons in an event.\n"
             + "e.g. view sumobot festival";
 
-    public static final String MESSAGE_SUCCESS = "Viewing event: %1$s";
+    public static final String MESSAGE_SUCCESS = "Listing contacts of event: %1$s";
 
     private final Index targetIndex;
 

--- a/src/main/java/seedu/address/logic/commands/searchmode/ExitSearchModeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/searchmode/ExitSearchModeCommand.java
@@ -13,9 +13,10 @@ import seedu.address.model.event.EventManager;
  */
 public class ExitSearchModeCommand extends Command {
     public static final String COMMAND_WORD = "exitsearch";
+    public static final String COMMAND_WORD_SHORT_FORM = "es";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits search mode.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " or " + COMMAND_WORD_SHORT_FORM + ": Exits "
+            + "search mode.\nExample: " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Exited search mode.";
 

--- a/src/main/java/seedu/address/logic/commands/searchmode/InitSearchModeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/searchmode/InitSearchModeCommand.java
@@ -13,9 +13,10 @@ import seedu.address.model.event.EventManager;
  */
 public class InitSearchModeCommand extends Command {
     public static final String COMMAND_WORD = "searchmode";
+    public static final String COMMAND_WORD_SHORT_FORM = "sm";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Enters search mode.\n"
-            + "Example: " + COMMAND_WORD;
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " or " + COMMAND_WORD_SHORT_FORM + ": Enters "
+            + "search mode.\nExample: " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Entered search mode.";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.contact.commands.ListCommand;
 import seedu.address.logic.commands.event.commands.AddEventCommand;
 import seedu.address.logic.commands.event.commands.AddPersonToEventCommand;
 import seedu.address.logic.commands.event.commands.DeleteEventCommand;
+import seedu.address.logic.commands.event.commands.EventAddAllCommand;
 import seedu.address.logic.commands.event.commands.FindEventCommand;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.logic.commands.searchmode.ExitSearchModeCommand;
@@ -33,6 +34,7 @@ import seedu.address.logic.parser.contact.parser.FindNameCommandParser;
 import seedu.address.logic.parser.contact.parser.FindRoleCommandParser;
 import seedu.address.logic.parser.event.parser.AddPersonToEventParser;
 import seedu.address.logic.parser.event.parser.DeleteEventCommandParser;
+import seedu.address.logic.parser.event.parser.EventAddAllCommandParser;
 import seedu.address.logic.parser.event.parser.FindEventCommandParser;
 import seedu.address.logic.parser.event.parser.NewEventCommandParser;
 import seedu.address.logic.parser.event.parser.RemovePersonFromEventParser;
@@ -104,6 +106,7 @@ public class AddressBookParser {
             return new NewEventCommandParser().parse(arguments);
 
         case InitSearchModeCommand.COMMAND_WORD:
+        case InitSearchModeCommand.COMMAND_WORD_SHORT_FORM:
             return new InitSearchModeCommand();
 
         case FindEventCommand.COMMAND_WORD:
@@ -148,14 +151,18 @@ public class AddressBookParser {
         logger.fine("Command word: " + commandWord + "; Arguments: " + arguments);
         switch (commandWord) {
         case ExitSearchModeCommand.COMMAND_WORD:
+        case ExitSearchModeCommand.COMMAND_WORD_SHORT_FORM:
             return new ExitSearchModeCommand();
         case SearchModeSearchCommand.COMMAND_WORD:
             return new SearchModeSearchCommandParser().parse(arguments);
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
+        case EventAddAllCommand.COMMAND_WORD:
+            return new EventAddAllCommandParser().parse(arguments);
         default:
             throw new ParseException(
-                    MESSAGE_UNKNOWN_COMMAND + "\nYou are in searchmode.\nUse only search, exitsearch or exit");
+                    MESSAGE_UNKNOWN_COMMAND + "\nYou are in searchmode.\nUse only search, exitsearch (es), "
+                            + "add-all or exit");
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/contact/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/parser/AddCommandParser.java
@@ -60,7 +60,6 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Person person = new Person(name, phone, email, address, telegramUsername, roleList);
 
-
         return new AddCommand(person);
     }
 

--- a/src/main/java/seedu/address/logic/parser/event/parser/EventAddAllCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/parser/EventAddAllCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser.event.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.event.commands.EventAddAllCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses user input to create a new EventAddAllCommand object.
+ */
+public class EventAddAllCommandParser implements Parser<EventAddAllCommand> {
+    /**
+     * Parses the given {@code String} of user input in the context of the EventAddAllCommand
+     * and returns an EventAddAllCommand object for execution.
+     *
+     * @param userInput The user input string to parse.
+     * @return EventAddAllCommand object based on the parsed index.
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    public EventAddAllCommand parse(String userInput) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(userInput);
+            return new EventAddAllCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EventAddAllCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/event/commands/EventAddAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/EventAddAllCommandTest.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.commands.event.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalEvents.EMPTY_EVENT;
+import static seedu.address.testutil.TypicalEvents.FILLED_EVENT;
+import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.event.EventManager;
+
+public class EventAddAllCommandTest {
+    private EventAddAllCommand eventAddAllCommand = new EventAddAllCommand(INDEX_FIRST_EVENT);
+
+    @Test
+    public void execute_invalidEventIndex_throwsCommandException() {
+        Model model = new ModelManager();
+        String expectedMsg = Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX;
+        assertCommandFailure(eventAddAllCommand, model, expectedMsg);
+    }
+    @Test
+    public void execute_emptyContactList_throwsCommandException() {
+        Model model = new ModelManager(new AddressBook(), getTypicalEventManager(), new UserPrefs());
+        String expectedMsg = Messages.MESSAGE_EMPTY_CONTACTS_ON_ADDALL;
+        assertCommandFailure(eventAddAllCommand, model, expectedMsg);
+    }
+
+    @Test
+    public void execute_correctInputs_success() {
+        EventManager eventManager = new EventManager();
+        eventManager.addEvent(EMPTY_EVENT);
+        Model model = new ModelManager(getTypicalAddressBook(), eventManager, new UserPrefs());
+        CommandResult expectedCommandResult = new CommandResult("Contacts added to Event to be filled "
+                + "successfully: \n"
+                + "Attendee(s): Alice Pauline, Fiona Kunz\n"
+                + "Volunteer(s): Elle Meyer\n"
+                + "Vendor(s): Daniel Meier, George Best\n"
+                + "Sponsor(s): Benson Meier, Carl Kurz");
+
+        EventManager expectedEventManager = new EventManager();
+        expectedEventManager.addEvent(FILLED_EVENT);
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), expectedEventManager, new UserPrefs());
+        assertCommandSuccess(eventAddAllCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    void testEquals_sameObject() {
+        EventAddAllCommand command = new EventAddAllCommand(INDEX_FIRST_EVENT);
+        assertTrue(command.equals(command));
+    }
+
+    @Test
+    void testEquals_differentType() {
+        EventAddAllCommand command = new EventAddAllCommand(INDEX_FIRST_EVENT);
+        String otherObject = "NotAnEventAddAllCommand";
+        assertFalse(command.equals(otherObject));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalEvents.SPORTS_FESTIVAL;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -31,7 +30,7 @@ import seedu.address.logic.commands.contact.commands.ListCommand;
 import seedu.address.logic.commands.event.commands.AddEventCommand;
 import seedu.address.logic.commands.event.commands.AddPersonToEventCommand;
 import seedu.address.logic.commands.event.commands.DeleteEventCommand;
-import seedu.address.logic.commands.event.commands.FindEventCommand;
+import seedu.address.logic.commands.event.commands.EventAddAllCommand;
 import seedu.address.logic.commands.event.commands.RemovePersonFromEventCommand;
 import seedu.address.logic.commands.searchmode.ExitSearchModeCommand;
 import seedu.address.logic.commands.searchmode.SearchModeSearchCommand;
@@ -167,15 +166,22 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseFindRoleCommand_unrecognisedInput_throwsParseException() {
+    public void parseFindRoleCommand_eventAddAllCommand() throws ParseException {
+        Command expected = new EventAddAllCommand(INDEX_FIRST_EVENT);
+        assertEquals(expected, new AddressBookParser()
+                .parseFindRoleCommand(EventAddAllCommand.COMMAND_WORD + " 1"));
+    }
+
+    @Test
+    public void parseFindRoleCommand_emptyInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 HelpCommand.MESSAGE_USAGE), () -> parser.parseFindRoleCommand(""));
     }
 
-    public void parseCommand_viewEvent() throws ParseException {
-        Command expected = new FindEventCommand(INDEX_FIRST_EVENT);
-        assertEquals(expected, new AddressBookParser()
-                .parseCommand(FindEventCommand.COMMAND_WORD + " " + SPORTS_FESTIVAL.getName()));
+    @Test
+    public void parseFindRoleCommand_unrecognisedInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND + "\nYou are in searchmode.\nUse "
+                + "only search, exitsearch (es), add-all or exit", () -> parser.parseFindRoleCommand("random"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -188,8 +188,8 @@ public class AddressBookParserTest {
     @Test
     public void parseSearchModeCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND + "\nYou are in searchmode.\nUse "
-                + "only search, exitsearch (es), add-all or exit",
-                () -> parser.parseSearchModeCommand("random"));
+                + "only search, exitsearch (es), add-all or exit", () ->
+                parser.parseSearchModeCommand("random"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/event/parser/EventAddAllCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/event/parser/EventAddAllCommandParserTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser.event.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.event.commands.EventAddAllCommand;
+
+public class EventAddAllCommandParserTest {
+    private EventAddAllCommandParser eventAddAllCommandParser = new EventAddAllCommandParser();
+    @Test
+    public void parse_invalidInputs_throwsParseException() {
+        assertParseFailure(eventAddAllCommandParser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EventAddAllCommand.MESSAGE_USAGE));
+        assertParseFailure(eventAddAllCommandParser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EventAddAllCommand.MESSAGE_USAGE));
+        assertParseFailure(eventAddAllCommandParser, "cat", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EventAddAllCommand.MESSAGE_USAGE));
+        assertParseFailure(eventAddAllCommandParser, "1.5", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EventAddAllCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validInputWithoutWhiteSpace_success() {
+        EventAddAllCommand expectedCommand = new EventAddAllCommand(INDEX_FIRST_EVENT);
+        assertParseSuccess(eventAddAllCommandParser, "1", expectedCommand);
+    }
+
+    @Test
+    public void parse_validInputWithWhiteSpace_success() {
+        EventAddAllCommand expectedCommand = new EventAddAllCommand(INDEX_FIRST_EVENT);
+        assertParseSuccess(eventAddAllCommandParser, "  1    ", expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -52,6 +52,14 @@ public class TypicalEvents {
             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
             .build();
 
+    public static final Event EMPTY_EVENT = new EventBuilder().withName("Event to be filled").build();
+    public static final Event FILLED_EVENT = new EventBuilder().withName("Event to be filled")
+            .withAttendees(getPersonSet(TypicalPersons.ALICE, TypicalPersons.FIONA))
+            .withVendors(getPersonSet(TypicalPersons.DANIEL, TypicalPersons.GEORGE))
+            .withSponsors(getPersonSet(TypicalPersons.BENSON, TypicalPersons.CARL))
+            .withVolunteers(getPersonSet(TypicalPersons.ELLE))
+            .build();
+
 
     private TypicalEvents() {} // prevents instantiation
 


### PR DESCRIPTION
1. From searchmode, user can type "add-all EVENT INDEX" to add all contacts from searchmode to the event. The current implementation adds the contact to all the roles of the event that he/she has. e.g. if Alice is both an attendee and sponsor, she will be added as both an attendee and sponsor to the event by default.
2. Changed the command word for "eventadd" back to "event-add"
3. Added short form for searchmode: "sm" and exitsearch: "es" for greater ease of manoeuvring in and out of searchmode.