### PR TITLE
Update edit command to remove contact from event role

### DIFF
--- a/src/main/java/seedu/address/logic/commands/contact/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/EditCommand.java
@@ -104,6 +104,7 @@ public class EditCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         // edit person for eventManager
         eventManager.editAllPersonsInEvents(personToEdit, editedPerson);
+        eventManager.updateEvents();
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -8,8 +8,12 @@ import java.util.Set;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Person;
+import seedu.address.model.role.Attendee;
 import seedu.address.model.role.Role;
 import seedu.address.model.role.RoleHandler;
+import seedu.address.model.role.Sponsor;
+import seedu.address.model.role.Vendor;
+import seedu.address.model.role.Volunteer;
 import seedu.address.model.role.exceptions.InvalidRoleException;
 import seedu.address.ui.Observer;
 
@@ -268,7 +272,13 @@ public class Event {
      */
     public void editPerson(Person personToEdit, Person editedPerson) {
         requireAllNonNull(personToEdit, editedPerson);
+
+        removeContactFromEventRoleOnEdit(personToEdit, editedPerson);
         // check each set and see it contains the person to edit
+        editContactAcrossAllRoles(personToEdit, editedPerson);
+    }
+
+    private void editContactAcrossAllRoles(Person personToEdit, Person editedPerson) {
         if (attendees.contains(personToEdit)) {
             attendees.remove(personToEdit);
             attendees.add(editedPerson);
@@ -289,6 +299,22 @@ public class Event {
             volunteers.add(editedPerson);
         }
     }
+
+    private void removeContactFromEventRoleOnEdit(Person personToEdit, Person editedPerson) {
+        if (!editedPerson.hasRole(new Attendee())) {
+            attendees.remove(personToEdit);
+        }
+        if (!editedPerson.hasRole(new Volunteer())) {
+            volunteers.remove(personToEdit);
+        }
+        if (!editedPerson.hasRole(new Vendor())) {
+            vendors.remove(personToEdit);
+        }
+        if (!editedPerson.hasRole(new Sponsor())) {
+            sponsors.remove(personToEdit);
+        }
+    }
+
     @Override
     public boolean equals(Object other) { // equality of 2 events defined only by the event name
         return other == this // short circuit if same object

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalEvents.TECH_CONFERENCE_EDITED;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.EDITED_ALICE;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -323,5 +326,12 @@ public class EventTest {
     public void testGetTotalNumberOfDistinctContacts() {
         Event event = TypicalEvents.getTypicalEvents().get(0);
         assertEquals(event.getTotalNumberOfDistinctContacts(), 6);
+    }
+
+    @Test
+    public void testRemoveContactFromEventRoleOnEdit() {
+        Event event = TypicalEvents.getTypicalEvents().get(0);
+        event.editPerson(ALICE, EDITED_ALICE);
+        assertEquals(event, TECH_CONFERENCE_EDITED);
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalEvents.java
+++ b/src/test/java/seedu/address/testutil/TypicalEvents.java
@@ -60,6 +60,13 @@ public class TypicalEvents {
             .withVolunteers(getPersonSet(TypicalPersons.ELLE))
             .build();
 
+    public static final Event TECH_CONFERENCE_EDITED = new EventBuilder().withName("Tech Conference 2024")
+            .withAttendees(getPersonSet(TypicalPersons.FIONA))
+            .withVendors(getPersonSet(TypicalPersons.DANIEL))
+            .withSponsors(getPersonSet(TypicalPersons.BENSON, TypicalPersons.CARL))
+            .withVolunteers(getPersonSet(TypicalPersons.ELLE))
+            .build();
+
 
     private TypicalEvents() {} // prevents instantiation
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -28,6 +28,12 @@ public class TypicalPersons {
 
             .withPhone("94351253")
             .withTelegramUsername("alice").withRoles("attendee").build();
+
+    public static final Person EDITED_ALICE = new PersonBuilder().withName("Alice Pauline")
+            .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
+
+            .withPhone("94351253")
+            .withTelegramUsername("alice").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")


### PR DESCRIPTION
Edit command that changes a contact's role will now remove the contact from event if he or she no longer has that role

Fixes #149 