### PR TITLE
Change searchmodesearch to throw ParseException on empty input and change success messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/searchmode/SearchModeSearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/searchmode/SearchModeSearchCommand.java
@@ -23,7 +23,8 @@ public class SearchModeSearchCommand extends Command {
             + "Parameters: [Flag] [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " n/Amy Bob Charlie";
 
-    public static final String MESSAGE_SUCCESS = "Added all Persons who fit search parameter";
+    public static final String MESSAGE_SUCCESS = "Added Contacts %1$s who fit search parameter.";
+    public static final String MESSAGE_NO_PERSONS_FOUND = "No Contacts found with the search parameter.";
 
     //maintains a set of predicates, reducing them to get the final predicate in execute
     private final Set<Predicate<Person>> predicates = new HashSet<>();
@@ -40,13 +41,18 @@ public class SearchModeSearchCommand extends Command {
     public CommandResult execute(Model model, EventManager eventManager) {
         // combine the new predicates with the old ones
         Predicate<Person> currPredicate = model.getLastPredicate();
+        int originalSize = model.getFilteredPersonList().size();
         Predicate<Person> predicate = predicates.stream().reduce(Predicate::and).orElse(x -> true);
         Predicate<Person> newPredicate = currPredicate.or(predicate);
 
 
 
         model.updateFilteredListWithExclusions(newPredicate);
-        return new CommandResult(MESSAGE_SUCCESS);
+        int updatedSize = model.getFilteredPersonList().size();
+        if (updatedSize == originalSize) {
+            return new CommandResult(MESSAGE_NO_PERSONS_FOUND);
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, updatedSize - originalSize));
 
     }
 

--- a/src/main/java/seedu/address/logic/parser/SearchModeSearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchModeSearchCommandParser.java
@@ -49,6 +49,7 @@ public class SearchModeSearchCommandParser implements Parser<SearchModeSearchCom
         Set<Predicate<Person>> predicates = new HashSet<>();
         // if a field is present, AND with the predicate for that field
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+
             Predicate<Person> namePred = createPersonPredicate(argMultimap);
             predicates.add(namePred);
         }
@@ -93,33 +94,50 @@ public class SearchModeSearchCommandParser implements Parser<SearchModeSearchCom
         return rolePred;
     }
 
-    private static Predicate<Person> createTelegramPredicate(ArgumentMultimap argMultimap) {
+    private static Predicate<Person> createTelegramPredicate(ArgumentMultimap argMultimap) throws ParseException {
+
         String telegram = argMultimap.getValue(PREFIX_TELEGRAM).get().trim();
+        if (telegram.isBlank()) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    SearchModeSearchCommand.MESSAGE_USAGE));
+        }
         String[] telegramKeywords = telegram.split("\\s+");
         Predicate<Person> telegramPred = new TelegramContainsKeywordsPredicate(
                 Arrays.stream(telegramKeywords).toList());
         return telegramPred;
     }
 
-    private static Predicate<Person> createAddressPredicate(ArgumentMultimap argMultimap) {
+    private static Predicate<Person> createAddressPredicate(ArgumentMultimap argMultimap) throws ParseException {
         String address = argMultimap.getValue(PREFIX_ADDRESS).get().trim();
         String[] addressKeywords = address.split("\\s+");
+        if (address.isBlank()) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    SearchModeSearchCommand.MESSAGE_USAGE));
+        }
         Predicate<Person> addressPred = new AddressContainsKeywordsPredicate(
                 Arrays.stream(addressKeywords).toList());
         return addressPred;
     }
 
-    private static Predicate<Person> createEmailPredicate(ArgumentMultimap argMultimap) {
+    private static Predicate<Person> createEmailPredicate(ArgumentMultimap argMultimap) throws ParseException {
         String email = argMultimap.getValue(PREFIX_EMAIL).get().trim();
         String[] emailKeywords = email.split("\\s+");
-
+        if (email.isBlank()) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    SearchModeSearchCommand.MESSAGE_USAGE));
+        }
         Predicate<Person> emailPred = new EmailContainsKeywordsPredicate(
                 Arrays.stream(emailKeywords).toList());
         return emailPred;
     }
 
-    private static Predicate<Person> createPhonePredicate(ArgumentMultimap argMultimap) {
+    private static Predicate<Person> createPhonePredicate(ArgumentMultimap argMultimap) throws ParseException {
+
         String phone = argMultimap.getValue(PREFIX_PHONE).get().trim();
+        if (phone.isBlank()) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    SearchModeSearchCommand.MESSAGE_USAGE));
+        }
         String[] phoneKeywords = phone.split("\\s+");
 
         Predicate<Person> phonePred = new PhoneNumberContainsKeywordPredicate(
@@ -127,8 +145,12 @@ public class SearchModeSearchCommandParser implements Parser<SearchModeSearchCom
         return phonePred;
     }
 
-    private static Predicate<Person> createPersonPredicate(ArgumentMultimap argMultimap) {
+    private static Predicate<Person> createPersonPredicate(ArgumentMultimap argMultimap) throws ParseException {
         String name = argMultimap.getValue(PREFIX_NAME).get().trim();
+        if (name.isBlank()) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    SearchModeSearchCommand.MESSAGE_USAGE));
+        }
 
         String[] nameKeywords = name.split("\\s+");
 

--- a/src/test/java/seedu/address/logic/commands/searchmode/SearchModeSearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/searchmode/SearchModeSearchCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands.searchmode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
 
 import java.util.Collections;
 import java.util.function.Predicate;
@@ -10,13 +11,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.model.person.predicates.PersonIsRolePredicate;
 import seedu.address.model.role.RoleHandler;
 import seedu.address.model.role.exceptions.InvalidRoleException;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalPersons;
 
 public class SearchModeSearchCommandTest {
 
@@ -31,14 +36,18 @@ public class SearchModeSearchCommandTest {
 
     @Test
     public void execute_validPredicate_success() {
-        Predicate<Person> predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Amy"));
+        model = new ModelManager(TypicalPersons.getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
+        expectedModel = new ModelManager(TypicalPersons.getTypicalAddressBook(), getTypicalEventManager(),
+                new UserPrefs());
+        Predicate<Person> predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
 
         SearchModeSearchCommand command = new SearchModeSearchCommand(predicate);
+        model.updateFilteredPersonList(person -> false);
+        CommandResult result = command.execute(model, model.getEventManager());
 
-        model.updateFilteredPersonList(predicate);
-        CommandResult result = command.execute(model, null);
+        expectedModel.updateFilteredPersonList(predicate);
 
-        assertEquals(SearchModeSearchCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+        assertEquals(String.format(SearchModeSearchCommand.MESSAGE_SUCCESS, "1"), result.getFeedbackToUser());
         assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
     }
 
@@ -90,9 +99,9 @@ public class SearchModeSearchCommandTest {
         SearchModeSearchCommand command = new SearchModeSearchCommand(combinedPredicate);
 
         model.updateFilteredPersonList(combinedPredicate);
-        CommandResult result = command.execute(model, null);
+        CommandResult result = command.execute(model, model.getEventManager());
 
-        assertEquals(SearchModeSearchCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+        assertEquals(SearchModeSearchCommand.MESSAGE_NO_PERSONS_FOUND, result.getFeedbackToUser());
         assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
     }
 
@@ -104,28 +113,35 @@ public class SearchModeSearchCommandTest {
                 Collections.singletonList(RoleHandler.getRole("vendor")));
         Predicate<Person> combinedPredicate = namePredicate.and(rolePredicate);
 
+        PersonBuilder personBuilder = new PersonBuilder().withName("Amy").withRoles("vendor");
+        model.addPerson(personBuilder.build());
+        model.updateFilteredPersonList(person -> false);
         SearchModeSearchCommand command = new SearchModeSearchCommand(combinedPredicate);
 
-        model.updateFilteredPersonList(combinedPredicate);
-        CommandResult result = command.execute(model, null);
+        expectedModel.addPerson(personBuilder.build());
+        expectedModel.updateFilteredPersonList(combinedPredicate);
+        CommandResult result = command.execute(model, model.getEventManager());
 
-        assertEquals(SearchModeSearchCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+        assertEquals(String.format(SearchModeSearchCommand.MESSAGE_SUCCESS, 1), result.getFeedbackToUser());
         assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
     }
 
     @Test
     public void execute_orPredicates_success() throws InvalidRoleException {
-        Predicate<Person> namePredicate = new NameContainsKeywordsPredicate(Collections.singletonList("Amy"));
+        model = new ModelManager(TypicalPersons.getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
+        expectedModel = new ModelManager(TypicalPersons.getTypicalAddressBook(), getTypicalEventManager(),
+                new UserPrefs());
+        Predicate<Person> namePredicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
         Predicate<Person> rolePredicate = new PersonIsRolePredicate(
                 Collections.singletonList(RoleHandler.getRole("vendor")));
         Predicate<Person> combinedPredicate = namePredicate.or(rolePredicate);
 
         SearchModeSearchCommand command = new SearchModeSearchCommand(combinedPredicate);
+        model.updateFilteredPersonList(person -> false);
+        expectedModel.updateFilteredPersonList(combinedPredicate);
+        CommandResult result = command.execute(model, model.getEventManager());
 
-        model.updateFilteredPersonList(combinedPredicate);
-        CommandResult result = command.execute(model, null);
-
-        assertEquals(SearchModeSearchCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+        assertEquals(String.format(SearchModeSearchCommand.MESSAGE_SUCCESS, "3"), result.getFeedbackToUser());
         assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
     }
 
@@ -135,11 +151,30 @@ public class SearchModeSearchCommandTest {
         Predicate<Person> negatedPredicate = namePredicate.negate();
 
         SearchModeSearchCommand command = new SearchModeSearchCommand(negatedPredicate);
+        model = new ModelManager(TypicalPersons.getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
+        expectedModel = new ModelManager(TypicalPersons.getTypicalAddressBook(), getTypicalEventManager(),
+                new UserPrefs());
 
-        model.updateFilteredPersonList(negatedPredicate);
-        CommandResult result = command.execute(model, null);
+        model.updateFilteredPersonList(person -> false);
+        expectedModel.updateFilteredPersonList(negatedPredicate);
+        CommandResult result = command.execute(model, model.getEventManager());
+        //everyone except amy
+        assertEquals(String.format(SearchModeSearchCommand.MESSAGE_SUCCESS, "7"), result.getFeedbackToUser());
+        assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
+    }
 
-        assertEquals(SearchModeSearchCommand.MESSAGE_SUCCESS, result.getFeedbackToUser());
+    @Test
+    public void execute_noPersonsFound_success() {
+        Predicate<Person> namePredicate = new NameContainsKeywordsPredicate(Collections.singletonList("Obama"));
+        SearchModeSearchCommand command = new SearchModeSearchCommand(namePredicate);
+        model = new ModelManager(new AddressBook(), getTypicalEventManager(), new UserPrefs());
+        expectedModel = new ModelManager(new AddressBook(), getTypicalEventManager(), new UserPrefs());
+
+        model.updateFilteredPersonList(person -> false);
+        expectedModel.updateFilteredPersonList(namePredicate);
+        CommandResult result = command.execute(model, model.getEventManager());
+
+        assertEquals(SearchModeSearchCommand.MESSAGE_NO_PERSONS_FOUND, result.getFeedbackToUser());
         assertEquals(model.getFilteredPersonList(), expectedModel.getFilteredPersonList());
     }
 

--- a/src/test/java/seedu/address/logic/parser/SearchModeSearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchModeSearchCommandParserTest.java
@@ -78,4 +78,33 @@ public class SearchModeSearchCommandParserTest {
         assertParseSuccess(parser, " n/Amy p/1234567 e/test@gmail.com"
                 + " r/attendee a/123 Road", expectedCommand);
     }
+
+    @Test
+    public void parse_emptyTeleFlagField_throwsParseException() {
+        assertParseFailure(parser, " t/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SearchModeSearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyRoleFlagField_throwsParseException() {
+        assertParseFailure(parser, " r/", String.format(RoleHandler.MESSAGE_CONSTRAINTS));
+    }
+
+    @Test
+    public void parse_emptyNameFlagField_throwsParseException() {
+        assertParseFailure(parser, " n/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SearchModeSearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyPhoneFlagField_throwsParseException() {
+        assertParseFailure(parser, " p/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SearchModeSearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyEmailFlagField_throwsParseException() {
+        assertParseFailure(parser, " e/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SearchModeSearchCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/SearchModeSearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchModeSearchCommandParserTest.java
@@ -15,11 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.searchmode.SearchModeSearchCommand;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.predicates.AddressContainsKeywordsPredicate;
-import seedu.address.model.person.predicates.EmailContainsKeywordsPredicate;
-import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
-import seedu.address.model.person.predicates.PersonIsRolePredicate;
-import seedu.address.model.person.predicates.PhoneNumberContainsKeywordPredicate;
+import seedu.address.model.person.predicates.*;
 import seedu.address.model.role.RoleHandler;
 import seedu.address.model.role.exceptions.InvalidRoleException;
 
@@ -106,5 +102,18 @@ public class SearchModeSearchCommandParserTest {
     public void parse_emptyEmailFlagField_throwsParseException() {
         assertParseFailure(parser, " e/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 SearchModeSearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyAddressFlagField_throwsParseException() {
+        assertParseFailure(parser, " a/", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                SearchModeSearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_telegFlagField_success() {
+        SearchModeSearchCommand expectedCommand = new SearchModeSearchCommand(
+                new TelegramContainsKeywordsPredicate(Collections.singletonList("Amy123")));
+        assertParseSuccess(parser, " t/Amy123", expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/SearchModeSearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchModeSearchCommandParserTest.java
@@ -15,7 +15,12 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.searchmode.SearchModeSearchCommand;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.predicates.*;
+import seedu.address.model.person.predicates.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
+import seedu.address.model.person.predicates.PersonIsRolePredicate;
+import seedu.address.model.person.predicates.PhoneNumberContainsKeywordPredicate;
+import seedu.address.model.person.predicates.TelegramContainsKeywordsPredicate;
 import seedu.address.model.role.RoleHandler;
 import seedu.address.model.role.exceptions.InvalidRoleException;
 


### PR DESCRIPTION
Closes #198 , 
Closes #196 
Changes Searchmodesearch to throw a ParseException with invalid command if empty flag inputs are present

Change the user response message to show how many people were added on successful search and No persons found message on  no matching search