### PR TITLE
Update find event to show contacts with event specific roles

### DIFF
--- a/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
@@ -2,8 +2,10 @@ package seedu.address.logic.commands.event.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -13,6 +15,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Person;
 
 
 /**
@@ -50,7 +53,23 @@ public class FindEventCommand extends Command {
 
         model.updateFilteredPersonList(eventManager.getPersonInEventPredicate(eventToView));
 
+        updateContactsUiWithEventSpecificRoles(model, eventToView);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, eventToView.getName()));
+    }
+
+    private static void updateContactsUiWithEventSpecificRoles(Model model, Event eventToView) {
+        ObservableList<Person> persons = model.getFilteredPersonList();
+        ArrayList<Person> tempListOfPersons = new ArrayList<>();
+        for (Person person : persons) {
+            Person personWithEventSpecificRoles = new Person(person.getName(), person.getPhone(), person.getEmail(),
+                    person.getAddress(), person.getTelegramUsername(), eventToView.makeRoles(person));
+            personWithEventSpecificRoles.addObserver(person.getObserver());
+            tempListOfPersons.add(personWithEventSpecificRoles);
+        }
+        for (Person person : tempListOfPersons) {
+            person.showContactWithEventSpecificRoles();
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -401,4 +401,30 @@ public class Event {
         this.vendors.clear();
         this.sponsors.clear();
     }
+
+    /**
+     * Determines the roles a given person has in this event.
+     * Checks if the specified person is contained within the attendees, volunteers,
+     * vendors, and sponsors sets, and adds the corresponding role to a HashSet.
+     *
+     * @param person the person whose roles in the event are being determined
+     * @return a HashSet of {@code Role} objects that the specified person holds in this event
+     *         (e.g., Attendee, Volunteer, Vendor, Sponsor)
+     */
+    public HashSet<Role> makeRoles(Person person) {
+        HashSet<Role> roles = new HashSet<>();
+        if (this.attendees.contains(person)) {
+            roles.add(new Attendee());
+        }
+        if (this.volunteers.contains(person)) {
+            roles.add(new Volunteer());
+        }
+        if (this.vendors.contains(person)) {
+            roles.add(new Vendor());
+        }
+        if (this.sponsors.contains(person)) {
+            roles.add(new Sponsor());
+        }
+        return roles;
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.role.Role;
+import seedu.address.ui.Observer;
 
 
 /**
@@ -29,6 +30,8 @@ public class Person implements Comparable<Person> {
     private final TelegramUsername telegramUsername;
     private final Set<Role> roles = new HashSet<>();
     private UUID uniqueId;
+
+    private Observer observer;
 
     /**
      * Every field must be present and not null
@@ -204,5 +207,36 @@ public class Person implements Comparable<Person> {
     @Override
     public int compareTo(Person other) {
         return this.getName().compareTo(other.getName());
+    }
+
+    /**
+     * Adds an observer to this object. The observer will be notified of any changes
+     * through the observer pattern when specific events occur.
+     *
+     * @param observer the {@code Observer} instance to be added
+     */
+    public void addObserver(Observer observer) {
+        this.observer = observer;
+    }
+
+    /**
+     * Retrieves the observer currently associated with this object.
+     *
+     * @return the current {@code Observer} instance observing this object, or {@code null}
+     *         if no observer has been added
+     */
+    public Observer getObserver() {
+        return this.observer;
+    }
+
+    /**
+     * Notifies the observer of any changes or updates that are specific to event-specific
+     * roles for a contact. This method checks if an observer exists and, if so, calls
+     * its {@code update} method, passing this instance as a parameter.
+     */
+    public void showContactWithEventSpecificRoles() {
+        if (this.observer != null) {
+            this.observer.update(this);
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/EventCard.java
+++ b/src/main/java/seedu/address/ui/EventCard.java
@@ -8,6 +8,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.event.Event;
+import seedu.address.model.person.Person;
 
 
 /**
@@ -69,5 +70,10 @@ public class EventCard extends UiPart<Region> implements Observer {
         sponsors.setText("Sponsors: " + event.getSponsors().size());
         volunteers.setText("Volunteers: " + event.getVolunteers().size());
         total.setText("Total: " + event.getTotalNumberOfDistinctContacts());
+    }
+
+    @Override
+    public void update(Person person) {
+
     }
 }

--- a/src/main/java/seedu/address/ui/Observer.java
+++ b/src/main/java/seedu/address/ui/Observer.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import seedu.address.model.person.Person;
+
 /**
  * Represents an observer in the observer design pattern.
  * <p>
@@ -19,4 +21,5 @@ public interface Observer {
      * </p>
      */
     public void update();
+    public void update(Person person);
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -16,7 +16,7 @@ import seedu.address.model.role.Role;
 /**
  * An UI component that displays information of a {@code Person}.
  */
-public class PersonCard extends UiPart<Region> {
+public class PersonCard extends UiPart<Region> implements Observer {
 
     private static final String FXML = "PersonListCard.fxml";
 
@@ -96,5 +96,18 @@ public class PersonCard extends UiPart<Region> {
         if (teleUsername != null) {
             telegramUsername.setText("@" + teleUsername);
         }
+    }
+
+    @Override
+    public void update(Person person) {
+        roles.getChildren().clear();
+        person.getRoles().stream()
+                .sorted(Comparator.comparing(Role::getRoleName))
+                .forEach(this::addLabel);
+    }
+
+    @Override
+    public void update() {
+
     }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -41,9 +41,10 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                PersonCard personCard = new PersonCard(person, getIndex() + 1);
+                person.addObserver(personCard);
+                setGraphic(personCard.getRoot());
             }
         }
     }
-
 }

--- a/src/test/java/seedu/address/logic/commands/event/commands/FindEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/FindEventCommandTest.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.event.commands.FindEventCommand.MESSAGE_SUCCESS;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalEvents.TECH_CONFERENCE;
 import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -18,7 +21,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
-
+import seedu.address.model.person.PersonInEventPredicate;
 
 
 public class FindEventCommandTest {
@@ -66,5 +69,14 @@ public class FindEventCommandTest {
         String expected = FindEventCommand.class.getCanonicalName() + "{targetIndex=" + INDEX_FIRST_EVENT + "}";
         assertEquals(expected, findEventCommand.toString());
         System.out.println(eventToView.toString());
+    }
+
+    @Test
+    public void execute_validIndex_success() {
+        FindEventCommand findEventCommand = new FindEventCommand(Index.fromOneBased(1));
+        String expectedMsg = String.format(MESSAGE_SUCCESS, TECH_CONFERENCE.getName());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalEventManager(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(new PersonInEventPredicate(new Event(TECH_CONFERENCE)));
+        assertCommandSuccess(findEventCommand, model, expectedMsg, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalEvents.TECH_CONFERENCE;
 import static seedu.address.testutil.TypicalEvents.TECH_CONFERENCE_EDITED;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.EDITED_ALICE;
@@ -16,6 +17,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Person;
+import seedu.address.model.role.Attendee;
+import seedu.address.model.role.Role;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.TypicalEvents;
 import seedu.address.ui.Observer;
@@ -309,8 +312,12 @@ public class EventTest {
         }
     }
 
-    private class DummyObserver implements Observer {
+    public class DummyObserver implements Observer {
         public void update() {
+
+        }
+
+        public void update(Person person) {
 
         }
     }
@@ -333,5 +340,13 @@ public class EventTest {
         Event event = TypicalEvents.getTypicalEvents().get(0);
         event.editPerson(ALICE, EDITED_ALICE);
         assertEquals(event, TECH_CONFERENCE_EDITED);
+    }
+
+    @Test
+    public void testMakeRoles() {
+        HashSet<Role> roles = TECH_CONFERENCE.makeRoles(ALICE);
+        HashSet<Role> expectedRoles = new HashSet<>();
+        expectedRoles.add(new Attendee());
+        assertEquals(roles, expectedRoles);
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.role.RoleHandler;
 import seedu.address.model.role.exceptions.InvalidRoleException;
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.ui.Observer;
 
 public class PersonTest {
     @Test
@@ -220,4 +221,20 @@ public class PersonTest {
         assertFalse(BOB.isSameTelegram(editedBob));
     }
 
+    private class DummyObserver implements Observer {
+        public void update() {
+
+        }
+
+        public void update(Person person) {
+
+        }
+    }
+    @Test
+    public void testAddObserver() {
+        Observer dummyObserver = new PersonTest.DummyObserver();
+        Person person = ALICE;
+        person.addObserver(dummyObserver);
+        assertEquals(person.getObserver(), dummyObserver);
+    }
 }


### PR DESCRIPTION
On find-event, the contacts displayed will now show only their event specific roles

Fixes #170 