### PR TITLE
Add wrapping for event title for 3 lines

### DIFF
--- a/src/main/resources/view/BrownTheme.css
+++ b/src/main/resources/view/BrownTheme.css
@@ -153,6 +153,13 @@
 .cell_big_label_event {
     -fx-font-family: "Segoe UI Semibold";
     -fx-font-size: 20px;
+    -fx-max-height: 4.5em;  /* Allow exactly 3 lines worth of height for text wrapping*/
+    -fx-text-fill: #010504;
+}
+
+.cell_big_label_event_index {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 20px;
     -fx-text-fill: #010504;
 }
 

--- a/src/main/resources/view/EventListCard.fxml
+++ b/src/main/resources/view/EventListCard.fxml
@@ -17,15 +17,15 @@
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15" />
             </padding>
-            <HBox spacing="0.5" alignment="CENTER_LEFT">
-                <Label fx:id="id" styleClass="cell_big_label_event">
+            <HBox spacing="0.5" alignment="TOP_LEFT">
+                <Label fx:id="id" styleClass="cell_big_label_event_index">
                     <minWidth>
                         <!-- Ensures that the label text is never truncated -->
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
                 <HBox spacing="10" alignment="CENTER_LEFT">
-                    <Label fx:id="name" text="\$first" styleClass="cell_big_label_event" />
+                    <Label fx:id="name" text="\$first" styleClass="cell_big_label_event" wrapText="true"/>
                 </HBox>
             </HBox>
             <HBox>


### PR DESCRIPTION
Fix #155 

Allow wrapping of Event Title for maximum of 3 lines

Examples:
![image](https://github.com/user-attachments/assets/5de207ad-93f9-4c14-8a53-92727844fb60)
