### PR TITLE
Changed parse exception message for parseStringOfIndice

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -220,7 +220,7 @@ public class ParserUtil {
             }
 
             if (indices.contains(index)) {
-                throw new ParseException("There cannot be duplicate indices for the same role e.g. a/1,1");
+                throw new ParseException("There cannot be duplicate indices for the same flag e.g. a/1,1");
             }
             indices.add(index);
         }


### PR DESCRIPTION
Changed error message for parseStringOfIndices to be more general as it is used for exclude as well
Closes #228 