### PR TITLE
Fix bug where user is unable to add contact

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -111,7 +111,7 @@ public class Person implements Comparable<Person> {
         }
 
         // If either party has no telegram username, then just check for uniqueness in phone and email
-        if (!getTelegramUsername().hasUsername() || !otherPerson.getTelegramUsername().hasUsername()) {
+        if (!getTelegramUsername().hasUsername() || !otherPerson.hasTelegramUsername()) {
             return otherPerson.getPhone().equals(getPhone())
                     || otherPerson.getEmail().equals(getEmail());
         }
@@ -238,5 +238,14 @@ public class Person implements Comparable<Person> {
         if (this.observer != null) {
             this.observer.update(this);
         }
+    }
+
+    /**
+     * Checks if the person has a Telegram username.
+     *
+     * @return {@code true} if the Telegram username is present; {@code false} otherwise.
+     */
+    public boolean hasTelegramUsername() {
+        return this.telegramUsername.hasUsername();
     }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -43,11 +43,12 @@ public class UniquePersonList implements Iterable<Person> {
     public String[] findSameField(Person toCheck) {
         requireNonNull(toCheck);
         for (Person person : internalList) {
+            boolean doBothHaveTelegramUsername = person.hasTelegramUsername() && toCheck.hasTelegramUsername();
             if (person.isSamePhone(toCheck)) {
                 return new String[] {"phone", person.getPhone().value};
             } else if (person.isSameEmail(toCheck)) {
                 return new String[] {"email", person.getEmail().value};
-            } else if (person.isSameTelegram(toCheck)) {
+            } else if (doBothHaveTelegramUsername && person.isSameTelegram(toCheck)) {
                 return new String[] {"telegram", person.getTelegramUsername().telegramUsername};
             }
         }


### PR DESCRIPTION
Fixes #237 

The reason why the user sees the wrong error message is because there's a mismatch between the code that checks for duplicate persons and the error msg that prints out the reason for duplicate.

When checking for duplicates of 2 contacts based on telegram username, when either contact does not have a telegram username, then only their phone number and email need to be considered.

When printing out the error message, the code checks for telegram username equality even if either contact does not have a telegram username, and thus points out that 2 contacts are equal when they both do not have telegram usernames, represented by "null" and proceeds to show the wrong reason for duplication.

This PR attempts to fix this issue.