### PR TITLE
Fix searchmode bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/searchmode/SearchModeSearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/searchmode/SearchModeSearchCommand.java
@@ -24,7 +24,8 @@ public class SearchModeSearchCommand extends Command {
             + "Example: " + COMMAND_WORD + " n/Amy Bob Charlie";
 
     public static final String MESSAGE_SUCCESS = "Added %1$s Contacts who fit search parameter.";
-    public static final String MESSAGE_NO_PERSONS_FOUND = "No Contacts found with the search parameter.";
+    public static final String MESSAGE_NO_PERSONS_FOUND = "No contacts found with the search parameter.\n"
+            + "Either that or the contact is already in the search results.";
 
     //maintains a set of predicates, reducing them to get the final predicate in execute
     private final Set<Predicate<Person>> predicates = new HashSet<>();
@@ -44,8 +45,6 @@ public class SearchModeSearchCommand extends Command {
         int originalSize = model.getFilteredPersonList().size();
         Predicate<Person> predicate = predicates.stream().reduce(Predicate::and).orElse(x -> true);
         Predicate<Person> newPredicate = currPredicate.or(predicate);
-
-
 
         model.updateFilteredListWithExclusions(newPredicate);
         int updatedSize = model.getFilteredPersonList().size();

--- a/src/main/java/seedu/address/model/person/predicates/TelegramContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/TelegramContainsKeywordsPredicate.java
@@ -27,6 +27,9 @@ public class TelegramContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        if (!person.hasTelegramUsername()) {
+            return false;
+        }
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getTelegramUsername().toString(), keyword)
                                     || person.getTelegramUsername().toString()

--- a/src/test/java/seedu/address/model/predicates/TelegramContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/predicates/TelegramContainsKeywordPredicateTest.java
@@ -5,10 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramUsername;
 import seedu.address.model.person.predicates.TelegramContainsKeywordsPredicate;
 import seedu.address.testutil.PersonBuilder;
 public class TelegramContainsKeywordPredicateTest {
@@ -56,4 +63,12 @@ public class TelegramContainsKeywordPredicateTest {
         assertTrue(predicate.equals(predicateCopy));
     }
 
+    @Test
+    public void test_contactWithNoTelegramUsername_returnsFalse() {
+        List<String> keywords = Collections.singletonList("amybee");
+        TelegramContainsKeywordsPredicate predicate = new TelegramContainsKeywordsPredicate(keywords);
+        Person personWithNoTelegramUsername = new Person(new Name("Zeke Yaeger"), new Phone("8425131"),
+                new Email("zeke@example.com"), new Address("Eldia"), new TelegramUsername(null), new HashSet<>());
+        assertFalse(predicate.test(personWithNoTelegramUsername));
+    }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -74,6 +74,7 @@ public class TypicalPersons {
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTelegramUsername(VALID_TELEGRAM_BOB)
             .withRoles("attendee").build();
 
+
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
     private TypicalPersons() {} // prevents instantiation


### PR DESCRIPTION
Fixes #281
Fixes #272 

Search mode breaks down when a telegram username search is performed on contacts with no telegram username. This is because contacts with no telegram username have null as their telegram username field and calling a method on null leads to java.lang.reflect.invocationtargetexception.

This PR attempts to fix it by first checking if the contact has a telegram username. If the contact does not have a telegram username, then the predicate will immediately return false.

Furthermore, the error message when no contacts are found is made more general to accommodate the case when no contacts are found due to the contacts already existing in search results.