### PR TITLE
Fix telegram input validation constraint message to reflect true constraints

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -117,13 +117,15 @@ Adds a contact to the address book.
 
 Format: `add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TELEGRAM_USERNAME] [r/ROLE]…​`
 
-<div markdown="span" class="alert alert-primary">**Note:**
-A contact can have any number of roles (including 0), and the Telegram username is optional. The roles must be one of the following: attendee, vendor, volunteer and sponsor.
+<div markdown="span" class="alert alert-primary">:memo: **Note:**
+A contact can have any number of roles (including 0), and the Telegram username is optional. 
+The roles must be one of the following: attendee, vendor, volunteer and sponsor.
 </div>
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
 * `add n/Betsy Crowe e/bc@gmail.com a/New Street p/1234567 t/betsyyy r/sponsor`
+
 
 ![Successfully added a contact](images/AppImages/FeaturesAddCommand.png)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,6 +120,7 @@ Format: `add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TELEGRAM_USERNAME] [r/ROLE]â€¦â
 <div markdown="span" class="alert alert-primary">:memo: **Note:**
 A contact can have any number of roles (including 0), and the Telegram username is optional. 
 The roles must be one of the following: attendee, vendor, volunteer and sponsor.
+Telegram usernames must start with an alphabet.
 </div>
 
 Examples:

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -8,8 +8,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class TelegramUsername {
     public static final String MESSAGE_CONSTRAINTS =
-            "Telegram Usernames should only contain alphanumeric characters and underscores, "
-                    + "and be between 5 to 32 characters.";
+            "Telegram usernames should begin with an alphabet, should only contain "
+            + "alphanumeric characters and underscores, and be between 5 to 32 characters.";
 
     /*
      * The first character of the address must be an alphabet.

--- a/src/main/java/seedu/address/model/person/TelegramUsername.java
+++ b/src/main/java/seedu/address/model/person/TelegramUsername.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class TelegramUsername {
     public static final String MESSAGE_CONSTRAINTS =
-            "Telegram usernames should begin with an alphabet, should only contain "
+            "Telegram usernames should begin with an alphabet, contain only "
             + "alphanumeric characters and underscores, and be between 5 to 32 characters.";
 
     /*


### PR DESCRIPTION
- Fixes #245 
- Fixes #238 

I widened the error message to better reflect all the different constraints that could be leading to the input validation error.

So now, instead of just problem due to
- only alphanumeric and underscore
- 5 to 32 char

I widened the message to say that problem could be due to
- must start with alphabet
- only alphanumeric and underscore
- 5 to 32 char

I also added a note in the UG to reflect that Telegram Usernames must start with alphabet.

