### PR TITLE
Set minWidth for Telegram Username

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -18,7 +18,7 @@
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
-      <HBox spacing="0.5" alignment="CENTER_LEFT">
+      <HBox spacing="0.5" alignment="TOP_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
@@ -26,8 +26,8 @@
           </minWidth>
         </Label>
         <HBox spacing="10" alignment="CENTER_LEFT">
-          <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
-          <Label fx:id="telegramUsername" styleClass="cell_small_label" />
+          <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true" maxWidth="1400" maxHeight="50"/>
+          <Label fx:id="telegramUsername" styleClass="cell_small_label" minWidth="250"/>
         </HBox>
       </HBox>
       <FlowPane fx:id="roles" />


### PR DESCRIPTION
- Fixes #258 

Added minWdith to the Telegram username UI such that it is always on screen.

Added wrapping to the name such that it can wrap for 2 lines, but does not handle a really long name (meaning it still truncates)

![image](https://github.com/user-attachments/assets/38e37339-81bb-4e25-a246-14591fc81f38)
