### PR TITLE
Predicate defensive programming

### DIFF
--- a/src/main/java/seedu/address/model/person/predicates/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/AddressContainsKeywordsPredicate.java
@@ -18,6 +18,7 @@ public class AddressContainsKeywordsPredicate implements Predicate<Person> {
      * @param keywords List of keywords to search for in the address field.
      */
     public AddressContainsKeywordsPredicate(List<String> keywords) {
+
         this.keywords =
                 keywords.stream()
                         .filter(keyword -> !keyword.isBlank())

--- a/src/main/java/seedu/address/model/person/predicates/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/AddressContainsKeywordsPredicate.java
@@ -27,6 +27,9 @@ public class AddressContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        if (person.getAddress() == null) {
+            return false;
+        }
 
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword))

--- a/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
@@ -28,6 +28,9 @@ public class EmailContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        if (person.getEmail() == null) {
+            return false;
+        }
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword)
                                     || person.getEmail().value.toLowerCase().contains(keyword.toLowerCase()));

--- a/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/EmailContainsKeywordsPredicate.java
@@ -56,4 +56,5 @@ public class EmailContainsKeywordsPredicate implements Predicate<Person> {
         return keywords.equals(otherEmailContainsKeywordsPredicate.keywords);
     }
 
+
 }

--- a/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
@@ -29,6 +29,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+
         if (keywords.isEmpty()) {
             return false;
         }

--- a/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/NameContainsKeywordsPredicate.java
@@ -33,6 +33,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         if (keywords.isEmpty()) {
             return false;
         }
+        if (person.getName() == null) {
+            return false;
+        }
         List<String> filteredKeywords = keywords.stream()
                 .filter(keyword -> !keyword.isBlank())
                 .collect(Collectors.toList());

--- a/src/main/java/seedu/address/model/person/predicates/PersonIsRolePredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/PersonIsRolePredicate.java
@@ -20,6 +20,9 @@ public class PersonIsRolePredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        if (person.getRoles() == null) {
+            return false;
+        }
         return roles.stream()
                 .anyMatch(role -> person.getRoles().contains(role));
     }

--- a/src/main/java/seedu/address/model/person/predicates/PhoneNumberContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/PhoneNumberContainsKeywordPredicate.java
@@ -18,6 +18,7 @@ public class PhoneNumberContainsKeywordPredicate implements Predicate<Person> {
      * @param keywords List of keywords to search for in the phone number field.
      */
     public PhoneNumberContainsKeywordPredicate(List<String> keywords) {
+
         this.keywords =
                 keywords.stream()
                         .filter(keyword -> !keyword.isBlank())
@@ -27,6 +28,9 @@ public class PhoneNumberContainsKeywordPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        if (person.getPhone() == null) {
+            return false;
+        }
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword))
             || keywords.stream().allMatch(keyword -> person.getPhone().value.toLowerCase()

--- a/src/test/java/seedu/address/model/predicates/AddressContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/predicates/AddressContainsKeywordsPredicateTest.java
@@ -6,10 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.TelegramUsername;
 import seedu.address.model.person.predicates.AddressContainsKeywordsPredicate;
 import seedu.address.testutil.PersonBuilder;
 public class AddressContainsKeywordsPredicateTest {
@@ -92,5 +96,31 @@ public class AddressContainsKeywordsPredicateTest {
         assertFalse(firstPredicate.equals(secondPredicate));
     }
 
+    @Test
+    public void test_nullAddress_returnsFalse() {
+        AddressContainsKeywordsPredicate predicate = new AddressContainsKeywordsPredicate(
+                Collections.singletonList("Jurong"));
+        assertFalse(predicate.test(new PersonStubNullAddress()));
+    }
+
+    /**
+     * A stub class to test for null address as Person should have a non null address
+     */
+    private class PersonStubNullAddress extends Person {
+        private Address address = null;
+
+        public PersonStubNullAddress() {
+            super(new seedu.address.model.person.Name("Alice"), new seedu.address.model.person.Phone("12345678"),
+                    new seedu.address.model.person.Email("test@gmail.com"),
+                    new seedu.address.model.person.Address("123, Jurong West Ave 6, #08-111"),
+                    new TelegramUsername("alice"),
+                    new HashSet<>());
+        }
+
+        @Override
+        public Address getAddress() {
+            return this.address;
+        }
+    }
 
 }

--- a/src/test/java/seedu/address/model/predicates/EmailContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/predicates/EmailContainsKeywordsPredicateTest.java
@@ -4,10 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.TelegramUsername;
 import seedu.address.model.person.predicates.EmailContainsKeywordsPredicate;
 import seedu.address.testutil.PersonBuilder;
 public class EmailContainsKeywordsPredicateTest {
@@ -39,6 +43,30 @@ public class EmailContainsKeywordsPredicateTest {
         EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(keywords);
         EmailContainsKeywordsPredicate predicateCopy = new EmailContainsKeywordsPredicate(keywords);
         assertTrue(predicate.equals(predicateCopy));
+    }
+
+    @Test
+    public void test_nullEmail_returnsFalse() {
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(
+                Collections.singletonList("Jurong"));
+        assertFalse(predicate.test(new PersonStubNullEmail()));
+    }
+
+    private class PersonStubNullEmail extends Person {
+        private Email email = null;
+
+        public PersonStubNullEmail() {
+            super(new seedu.address.model.person.Name("Alice"), new seedu.address.model.person.Phone("12345678"),
+                    new seedu.address.model.person.Email("test@gmail.com"),
+                    new seedu.address.model.person.Address("123, Jurong West Ave 6, #08-111"),
+                    new TelegramUsername("alice"),
+                    new HashSet<>());
+        }
+
+        @Override
+        public Email getEmail() {
+            return this.email;
+        }
     }
 }
 

--- a/src/test/java/seedu/address/model/predicates/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/predicates/NameContainsKeywordsPredicateTest.java
@@ -6,10 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.TelegramUsername;
 import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.PersonBuilder;
 
@@ -99,4 +103,27 @@ public class NameContainsKeywordsPredicateTest {
     }
 
 
+    @Test
+    public void test_nullAddress_returnsFalse() {
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+                Collections.singletonList("Jurong"));
+        assertFalse(predicate.test(new PersonStubNullName()));
+    }
+
+    private class PersonStubNullName extends Person {
+        private Name name = null;
+
+        public PersonStubNullName() {
+            super(new seedu.address.model.person.Name("Alice"), new seedu.address.model.person.Phone("12345678"),
+                    new seedu.address.model.person.Email("test@gmail.com"),
+                    new seedu.address.model.person.Address("123, Jurong West Ave 6, #08-111"),
+                    new TelegramUsername("alice"),
+                    new HashSet<>());
+        }
+
+        @Override
+        public Name getName() {
+            return this.name;
+        }
+    }
 }

--- a/src/test/java/seedu/address/model/predicates/PhoneNumberContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/predicates/PhoneNumberContainsKeywordPredicateTest.java
@@ -5,10 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramUsername;
 import seedu.address.model.person.predicates.PhoneNumberContainsKeywordPredicate;
 import seedu.address.testutil.PersonBuilder;
 public class PhoneNumberContainsKeywordPredicateTest {
@@ -47,5 +51,29 @@ public class PhoneNumberContainsKeywordPredicateTest {
         PhoneNumberContainsKeywordPredicate predicate = new PhoneNumberContainsKeywordPredicate(keywords);
         assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
         assertTrue(predicate.test(new PersonBuilder().withPhone("87654321").build()));
+    }
+
+    @Test
+    public void test_nullAddress_returnsFalse() {
+        PhoneNumberContainsKeywordPredicate predicate = new PhoneNumberContainsKeywordPredicate(
+                Collections.singletonList("Jurong"));
+        assertFalse(predicate.test(new PersonStubNullPhoneNumber()));
+    }
+
+    private class PersonStubNullPhoneNumber extends Person {
+        private Phone phone = null;
+
+        public PersonStubNullPhoneNumber() {
+            super(new seedu.address.model.person.Name("Alice"), new seedu.address.model.person.Phone("12345678"),
+                    new seedu.address.model.person.Email("test@gmail.com"),
+                    new seedu.address.model.person.Address("123, Jurong West Ave 6, #08-111"),
+                    new TelegramUsername("alice"),
+                    new HashSet<>());
+        }
+
+        @Override
+        public Phone getPhone() {
+            return this.phone;
+        }
     }
 }


### PR DESCRIPTION
Adds defensive checks for Predicates to prevent further search mode exceptions
Should not be necessary as those fields are checked but could improve code quality and mitigate future bugs

Use equality check rather an assertions as these could lead to errors in runtime if other checks fail
**EDIT: Seems to be allowed**
![image](https://github.com/user-attachments/assets/6486bade-b737-4d58-8c5a-bc6fc43f0708)
Will merge by tmr if no one has any issues with it

Should not violate feature freeze?
Fits under:
Can be allowed only if the current behavior causes the software to misbehave (i.e., crash, give incorrect results, store inconsistent data, or make it unusable for typical users).

and improving code quality
![image](https://github.com/user-attachments/assets/ccfaec5c-d2d3-4ef1-b368-3fe7d210f163)
