### PR TITLE
Fix roles in event view

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -62,4 +62,8 @@ public interface Logic {
      * Get all persons in the address book.
      */
     ObservableList<Person> getAllPersons();
+
+    BooleanProperty getIsFindEvent();
+
+    ObservableList<Person> getContactListForFindEvent();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -110,15 +110,32 @@ public class LogicManager implements Logic {
     /**
      * Returns the search mode status.
      */
+    @Override
     public BooleanProperty getSearchMode() {
         return model.searchModeProperty();
 
     }
 
+    @Override
+    public BooleanProperty getIsFindEvent() {
+        return model.getIsFindEvent();
+    }
+
     /**
      * Get all persons in the address book.
      */
+    @Override
     public ObservableList<Person> getAllPersons() {
         return model.getAllPersons();
+    }
+
+    /**
+     * Retrieves the contact list filtered specifically for finding events.
+     *
+     * @return an {@code ObservableList<Person>} containing the contacts related to the current event search.
+     */
+    @Override
+    public ObservableList<Person> getContactListForFindEvent() {
+        return model.getContactListForFindEvent();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/contact/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/AddCommand.java
@@ -68,6 +68,7 @@ public class AddCommand extends Command {
         }
 
         model.addPerson(toAdd);
+        model.setIsFindEvent(false);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/contact/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/ClearCommand.java
@@ -23,6 +23,7 @@ public class ClearCommand extends Command {
         model.setAddressBook(new AddressBook());
         eventManager.clearAllContactsFromAllEvents();
         eventManager.updateEvents();
+        model.setIsFindEvent(false);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/contact/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/DeleteCommand.java
@@ -47,6 +47,7 @@ public class DeleteCommand extends Command {
         model.deletePerson(personToDelete);
         eventManager.removeAllPersonsInEvents(personToDelete);
         eventManager.updateEvents();
+        model.setIsFindEvent(false);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/contact/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/EditCommand.java
@@ -105,6 +105,7 @@ public class EditCommand extends Command {
         // edit person for eventManager
         eventManager.editAllPersonsInEvents(personToEdit, editedPerson);
         eventManager.updateEvents();
+        model.setIsFindEvent(false);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/contact/commands/FindNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/FindNameCommand.java
@@ -34,6 +34,7 @@ public class FindNameCommand extends Command {
     public CommandResult execute(Model model, EventManager eventManager) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        model.setIsFindEvent(false);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/contact/commands/FindRoleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/FindRoleCommand.java
@@ -33,6 +33,7 @@ public class FindRoleCommand extends Command {
     public CommandResult execute(Model model, EventManager eventManager) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        model.setIsFindEvent(false);
         return new CommandResult(
                 String.format(Messages.MESSAGE_USER_SEARCH_QUERY_ROLES, predicate.getRolesAsString()) + "\n"
                     + String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));

--- a/src/main/java/seedu/address/logic/commands/contact/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/commands/ListCommand.java
@@ -22,6 +22,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model, EventManager eventManager) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.setIsFindEvent(false);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddEventCommand.java
@@ -41,6 +41,7 @@ public class AddEventCommand extends Command {
         }
 
         eventManager.addEvent(eventToBeAdded);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, eventToBeAdded.getName()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
@@ -94,7 +94,6 @@ public class AddPersonToEventCommand extends Command {
 
         sb.delete(sb.length() - 1, sb.length());
         event.updateUi();
-        model.setIsFindEvent(false);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, sb, event.getName()));
     }

--- a/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommand.java
@@ -94,6 +94,8 @@ public class AddPersonToEventCommand extends Command {
 
         sb.delete(sb.length() - 1, sb.length());
         event.updateUi();
+        model.setIsFindEvent(false);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, sb, event.getName()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/event/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/DeleteEventCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands.event.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -13,6 +14,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonInEventPredicate;
 
 /**
  * Deletes an event from the address book.

--- a/src/main/java/seedu/address/logic/commands/event/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/DeleteEventCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands.event.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -14,8 +13,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventManager;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.PersonInEventPredicate;
 
 /**
  * Deletes an event from the address book.

--- a/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
@@ -46,6 +46,7 @@ public class FindEventCommand extends Command {
     public CommandResult execute(Model model, EventManager eventManager) throws CommandException {
         requireNonNull(eventManager);
         List<Event> events = eventManager.getEventList();
+        model.setIsFindEvent(false);
 
         if (targetIndex.getZeroBased() >= events.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_EVENT_DISPLAYED_INDEX);
@@ -69,9 +70,9 @@ public class FindEventCommand extends Command {
             personWithEventSpecificRoles.addObserver(person.getObserver());
             tempListOfPersons.add(personWithEventSpecificRoles);
         }
-        for (Person person : tempListOfPersons) {
-            person.showContactWithEventSpecificRoles();
-        }
+
+        model.setContactListForFindEvent(tempListOfPersons);
+        model.setIsFindEvent(true);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
@@ -61,7 +61,7 @@ public class FindEventCommand extends Command {
         return new CommandResult(String.format(MESSAGE_SUCCESS, eventToView.getName()));
     }
 
-    private static void updateContactsUiWithEventSpecificRoles(Model model, Event eventToView) {
+    public static void updateContactsUiWithEventSpecificRoles(Model model, Event eventToView) {
         ObservableList<Person> persons = model.getFilteredPersonList();
         ArrayList<Person> tempListOfPersons = new ArrayList<>();
         for (Person person : persons) {

--- a/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/FindEventCommand.java
@@ -61,6 +61,16 @@ public class FindEventCommand extends Command {
         return new CommandResult(String.format(MESSAGE_SUCCESS, eventToView.getName()));
     }
 
+    /**
+     * Updates the UI to display contacts with roles specific to a given event.
+     *
+     * <p>This method retrieves the current filtered list of persons from the model, creates copies of each person
+     * with roles that are specific to the provided event, and updates the model's contact list with these
+     * event-specific persons. Observers from the original persons are also copied to maintain UI updates.</p>
+     *
+     * @param model The model containing the data and methods for manipulating the contact list and event state.
+     * @param eventToView The event for which roles should be generated and assigned to each contact.
+     */
     public static void updateContactsUiWithEventSpecificRoles(Model model, Event eventToView) {
         ObservableList<Person> persons = model.getFilteredPersonList();
         ArrayList<Person> tempListOfPersons = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -85,11 +85,8 @@ public class RemovePersonFromEventCommand extends Command {
                 model.updateFilteredPersonList(eventManager.getPersonInEventPredicate(event));
             }
         }
+        model.setIsFindEvent(false);
         return new CommandResult(String.format(MESSAGE_SUCCESS, person.getName(), event.getName()));
-
-
-
-
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands.event.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;

--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands.event.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -77,16 +78,24 @@ public class RemovePersonFromEventCommand extends Command {
         event.removePerson(person, personRole);
         eventManager.setEvent(originalEvent, event);
         event.updateUi();
+
+        updateContactsIfInEventViewToShowRemovedContact(model, eventManager, event);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, person.getName(), event.getName()));
+    }
+
+    private static void updateContactsIfInEventViewToShowRemovedContact(Model model, EventManager eventManager,
+                                                                        Event event) {
         // check the last shown list if it is event
+        model.setIsFindEvent(false);
         Predicate<Person> lastPred = model.getLastPredicate();
         if (lastPred instanceof PersonInEventPredicate) {
             if (((PersonInEventPredicate) lastPred).getEvent().equals(event)) {
                 //create a new predicate for changed event
                 model.updateFilteredPersonList(eventManager.getPersonInEventPredicate(event));
+                FindEventCommand.updateContactsUiWithEventSpecificRoles(model, event);
             }
         }
-        model.setIsFindEvent(false);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, person.getName(), event.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/searchmode/InitSearchModeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/searchmode/InitSearchModeCommand.java
@@ -25,6 +25,7 @@ public class InitSearchModeCommand extends Command {
     @Override
     public CommandResult execute(Model model, EventManager eventManager) {
         requireNonNull(model);
+        model.setIsFindEvent(false);
         model.setSearchMode(true);
         // empties the current displayed list
         model.updateFilteredPersonList(person -> false);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -156,4 +157,12 @@ public interface Model {
 
 
     String[] findSameField(Person person);
+
+    BooleanProperty getIsFindEvent();
+
+    void setIsFindEvent(boolean isFindEvent);
+
+    void setContactListForFindEvent(ArrayList<Person> persons);
+
+    ObservableList<Person> getContactListForFindEvent();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -11,6 +12,7 @@ import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
@@ -31,12 +33,15 @@ public class ModelManager implements Model {
     private final EventManager eventManager;
     private final FilteredList<Person> filteredPersons;
 
+    private ObservableList<Person> contactListForFindEvent;
+
     /**
      * The set of persons that are excluded from the search. Reset upon exiting searchmode or clear command
      */
     private final Set<Person> excludedPersons = new HashSet<>();
 
     private BooleanProperty searchMode = new SimpleBooleanProperty(false);
+    private BooleanProperty isFindEvent = new SimpleBooleanProperty(false);
     private Predicate<Person> lastPredicate = PREDICATE_SHOW_ALL_PERSONS;
 
     /**
@@ -201,6 +206,14 @@ public class ModelManager implements Model {
     public BooleanProperty searchModeProperty() {
         return searchMode;
     }
+
+    public BooleanProperty getIsFindEvent() {
+        return isFindEvent;
+    }
+
+    public void setIsFindEvent(boolean isFindEvent) {
+        this.isFindEvent.set(isFindEvent);
+    }
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -272,4 +285,13 @@ public class ModelManager implements Model {
         return addressBook.findSameField(person);
     }
 
+    @Override
+    public void setContactListForFindEvent(ArrayList<Person> persons) {
+        this.contactListForFindEvent = FXCollections.observableList(persons);
+    }
+
+    @Override
+    public ObservableList<Person> getContactListForFindEvent() {
+        return this.contactListForFindEvent;
+    }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -76,6 +76,28 @@ public class MainWindow extends UiPart<Stage> {
 
         helpWindow = new HelpWindow();
         logic.getSearchMode().addListener((observable, oldValue, newValue) -> updateUiBasedOnSearchMode(newValue));
+        logic.getIsFindEvent().addListener((observable, oldValue, newValue) -> updateUiBasedOnFindEvent(newValue));
+    }
+
+    private void updateUiBasedOnFindEvent(boolean isFindEvent) {
+        HBox hbox = new HBox();
+        HBox.setHgrow(hbox, Priority.ALWAYS);
+        VBox.setVgrow(hbox, Priority.ALWAYS);
+        hbox.setPrefWidth(personListPanelPlaceholder.getWidth());
+        hbox.setPrefHeight(personListPanelPlaceholder.getHeight());
+        hbox.setSpacing(5);
+
+        if (isFindEvent) {
+            personListPanel = new PersonListPanel(logic.getContactListForFindEvent());
+        } else {
+            personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        }
+        HBox.setHgrow(personListPanel.getRoot(), Priority.ALWAYS);
+        hbox.getChildren().add(personListPanel.getRoot());
+        commandBoxPlaceholder.setStyle("");
+
+        personListPanelPlaceholder.getChildren().clear();
+        personListPanelPlaceholder.getChildren().add(hbox);
     }
 
     private void updateUiBasedOnSearchMode(boolean isSearchMode) {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CONTACT_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -193,5 +195,13 @@ public class LogicManagerTest {
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
     }
 
+    @Test
+    public void testGetContactListForFindEvent() {
+        assertNull(logic.getContactListForFindEvent());
+    }
 
+    @Test
+    public void testGetIsFindEvent() {
+        assertFalse(logic.getIsFindEvent().get());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/AddCommandTest.java
@@ -16,6 +16,8 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
@@ -242,6 +244,22 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public BooleanProperty getIsFindEvent() {
+            return new SimpleBooleanProperty(false);
+        };
+
+        public void setIsFindEvent(boolean isFindEvent) {
+
+        };
+
+        public void setContactListForFindEvent(ArrayList<Person> persons) {
+
+        };
+
+        public ObservableList<Person> getContactListForFindEvent() {
+            return FXCollections.observableArrayList();
+        };
     }
 
     /**

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -10,14 +10,18 @@ import static seedu.address.testutil.TypicalPersons.BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.person.predicates.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
@@ -212,5 +216,16 @@ public class ModelManagerTest {
     @Test
     public void excludePerson_personNotInAddressBook() {
         assertThrows(PersonNotFoundException.class, () -> modelManager.excludePerson(ALICE));
+    }
+
+    @Test
+    public void testGetContactListForFindEvent() {
+        ArrayList<Person> persons = new ArrayList<Person>();
+        persons.add(ALICE);
+
+        modelManager.setContactListForFindEvent(persons);
+
+        ObservableList<Person> expectedList = FXCollections.observableList(persons);
+        assertEquals(expectedList, modelManager.getContactListForFindEvent());
     }
 }


### PR DESCRIPTION
An initial solution to #170 was done using an Observer pattern to update the Person Card with event-specific roles on find-event command.

However, due to JavaFX lazy evaluation and creation of PersonCard Object, there will be instances where Person does not have an Observer and is thus unable to update the Person Card to display event specific roles when find-event command is called. This results in the GUI occasionally rendering the contacts' general roles instead of their event specific roles, making it buggy and inconsistent.

In order to work around that, I have decided to use a new approach where I render from a different list of contacts specifically when there is a find-event command called, based on the boolean property isFindEvent. To follow up on that, I made execution of other commands set the find-event status back to false so as to render the default filtered list of persons.

This PR aims to fix the buggy implementation of Observer pattern for a previous issue #170 in v1.5.