### PR TITLE
Fix add-all to show error when adding contact with no role

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -27,6 +27,9 @@ public class Messages {
     public static final String MESSAGE_USER_SEARCH_QUERY_ROLES = "Displaying search results for all contacts "
             + "with the roles: %s";
 
+    public static final String MESSAGE_ADD_CONTACT_WITH_NO_ROLES_TO_EVENT = "The contact: %1s you are adding"
+            + " does not have a role.";
+
     public static final String SEARCHMODE_UNKNOWN_COMMAND = "\nYou are in search-mode."
             + "\nUse only search, exit-search(es), "
             + "add-all(aa), exclude, check-excluded(chx), clear-excluded(clx) or exit.";

--- a/src/main/java/seedu/address/logic/commands/event/commands/EventAddAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/EventAddAllCommand.java
@@ -60,6 +60,10 @@ public class EventAddAllCommand extends Command {
         }
         for (int i = 0; i < persons.size(); i++) {
             Person person = persons.get(i);
+            if (person.getRoles().isEmpty()) {
+                throw new CommandException(String.format(Messages.MESSAGE_ADD_CONTACT_WITH_NO_ROLES_TO_EVENT,
+                        person.getName()));
+            }
             Index indexToAdd = Index.fromZeroBased(i);
             if (person.hasRole(new Attendee())) {
                 attendees.add(indexToAdd);
@@ -73,7 +77,9 @@ public class EventAddAllCommand extends Command {
             if (person.hasRole(new Sponsor())) {
                 sponsors.add(indexToAdd);
             }
+
         }
+
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/event/commands/EventAddAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/EventAddAllCommandTest.java
@@ -10,6 +10,8 @@ import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_EVENT;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.HashSet;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
@@ -19,6 +21,12 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.EventManager;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.TelegramUsername;
 
 public class EventAddAllCommandTest {
     private EventAddAllCommand eventAddAllCommand = new EventAddAllCommand(INDEX_FIRST_EVENT);
@@ -55,15 +63,28 @@ public class EventAddAllCommandTest {
     }
 
     @Test
-    void testEquals_sameObject() {
+    public void testEquals_sameObject() {
         EventAddAllCommand command = new EventAddAllCommand(INDEX_FIRST_EVENT);
         assertTrue(command.equals(command));
     }
 
     @Test
-    void testEquals_differentType() {
+    public void testEquals_differentType() {
         EventAddAllCommand command = new EventAddAllCommand(INDEX_FIRST_EVENT);
         String otherObject = "NotAnEventAddAllCommand";
         assertFalse(command.equals(otherObject));
+    }
+
+    @Test
+    public void execute_addContactWithNoRole_throwsCommandException() {
+        AddressBook addressBook = new AddressBook();
+        Person personWithNoRoles = new Person(new Name("Saitama"), new Phone("12345678"), new Email("123@gmail.com"),
+                new Address("Blk 123"), new TelegramUsername(null), new HashSet<>());
+        addressBook.addPerson(personWithNoRoles);
+        Model model = new ModelManager(addressBook, getTypicalEventManager(), new UserPrefs());
+
+        assertCommandFailure(eventAddAllCommand, model, String.format(
+                Messages.MESSAGE_ADD_CONTACT_WITH_NO_ROLES_TO_EVENT,
+                personWithNoRoles.getName()));
     }
 }


### PR DESCRIPTION
Fixes #302 

Previously when adding contacts from search-mode using add-all command, when contact has no role, the result display does not say anything, in other words, it fails silently. 

This PR attempts to fix that by adding an error message when user tries to add contact with no role using add-all in search mode.