### PR TITLE
Prevent truncation for event name, contact name, address, email

### DIFF
--- a/src/main/java/seedu/address/logic/parser/event/parser/NewEventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/event/parser/NewEventCommandParser.java
@@ -27,14 +27,18 @@ public class NewEventCommandParser implements Parser<AddEventCommand> {
      *     {@code NewEventCommand#MESSAGE_USAGE}.
      */
     public AddEventCommand parse(String userInput) throws ParseException {
+        if (userInput.isBlank()) {
+            logger.log(Level.WARNING, "User inputted blank Event name, throw ParseException");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddEventCommand.MESSAGE_USAGE));
+        }
+
         try {
             Event event = ParserUtil.parseEvent(userInput);
             logger.log(Level.INFO, "Successfully parsed event: {0}", event);
             return new AddEventCommand(event);
         } catch (ParseException pe) {
             logger.log(Level.WARNING, "ParseException encountered: {0}", pe.getMessage());
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddEventCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(pe.getMessage());
         }
     }
 }

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -25,14 +25,13 @@ import seedu.address.ui.Observer;
 public class Event {
     public static final String MESSAGE_CONSTRAINTS = "Event name should not exceed 60 characters and "
             + "should not be blank.";
+    public static final String VALIDATION_REGEX = ".{1,60}";
     private final String name;
     private final Set<Person> attendees;
     private final Set<Person> vendors;
     private final Set<Person> sponsors;
     private final Set<Person> volunteers;
     private Observer observer;
-
-    public static final String VALIDATION_REGEX = ".{1,60}";
 
     /**
      * Constructs a {@code Event}.

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -1,6 +1,7 @@
 package seedu.address.model.event;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.HashSet;
@@ -22,13 +23,16 @@ import seedu.address.ui.Observer;
  * Represents an Event in the address book.
  */
 public class Event {
-    public static final String MESSAGE_CONSTRAINTS = "Event name should not be blank.";
+    public static final String MESSAGE_CONSTRAINTS = "Event name should not exceed 60 characters and "
+            + "should not be blank.";
     private final String name;
     private final Set<Person> attendees;
     private final Set<Person> vendors;
     private final Set<Person> sponsors;
     private final Set<Person> volunteers;
     private Observer observer;
+
+    public static final String VALIDATION_REGEX = ".{1,60}";
 
     /**
      * Constructs a {@code Event}.
@@ -37,12 +41,15 @@ public class Event {
      * @param name A valid event name.
      */
     public Event(String name) {
+        requireNonNull(name);
+        checkArgument(isValidEvent(name), MESSAGE_CONSTRAINTS);
         this.name = name;
         this.attendees = new HashSet<>();
         this.vendors = new HashSet<>();
         this.sponsors = new HashSet<>();
         this.volunteers = new HashSet<>();
     }
+
 
     /**
      * Constructs a {@code Event}.
@@ -57,6 +64,8 @@ public class Event {
     public Event(String name, Set<Person> attendees, Set<Person> vendors, Set<Person> sponsors,
                  Set<Person> volunteers) {
         requireNonNull(name);
+        requireNonNull(name);
+        checkArgument(isValidEvent(name), MESSAGE_CONSTRAINTS);
         this.name = name;
         this.attendees = attendees != null ? attendees : new HashSet<>();
         this.vendors = vendors != null ? vendors : new HashSet<>();
@@ -70,7 +79,10 @@ public class Event {
      * @param event {@code Event} that we want to copy.
      */
     public Event(Event event) {
-        this.name = event.getName();
+        String toCopyName = event.getName();
+        requireNonNull(toCopyName);
+        checkArgument(isValidEvent(toCopyName), MESSAGE_CONSTRAINTS);
+        this.name = toCopyName;
         this.attendees = event.getAttendees();
         this.vendors = event.getVendors();
         this.sponsors = event.getSponsors();
@@ -204,7 +216,7 @@ public class Event {
      * Returns true if a given string is a valid event.
      */
     public static boolean isValidEvent(String event) {
-        return !event.isEmpty();
+        return !event.isEmpty() && event.matches(VALIDATION_REGEX);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -9,13 +9,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank.";
+    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, "
+            + "but should not be blank, and should be less than 120 characters.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "[^\\s].{0,119}";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -19,7 +19,6 @@ public class Email {
             + "3. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
-            + "    - consist of at least 2 domain labels, namely a domain label and a top level domain (TLD) label\n"
             + "    - end with a top level domain (TLD) label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
@@ -30,7 +29,7 @@ public class Email {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -12,13 +12,15 @@ public class Email {
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
+            + "1. The total length of the email address should not exceed 120 characters long.\n"
+            + "2. The local-part should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
             + "characters.\n"
-            + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
+            + "3. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
+            + "    - consist of at least 2 domain labels, namely a domain label and a top level domain (TLD) label\n"
+            + "    - end with a top level domain (TLD) label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
@@ -28,7 +30,7 @@ public class Email {
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)+" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;
@@ -48,7 +50,7 @@ public class Email {
      * Returns if a given string is a valid email.
      */
     public static boolean isValidEmail(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.length() <= 120;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank.";
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank. "
+            + "Names cannot be more than 100 characters long.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{0,99}";
 
     public final String fullName;
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -18,7 +18,7 @@
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
-      <HBox spacing="0.5" alignment="CENTER_LEFT">
+      <HBox spacing="0.5" alignment="TOP_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
@@ -26,8 +26,8 @@
           </minWidth>
         </Label>
         <HBox spacing="10" alignment="CENTER_LEFT">
-          <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
-          <Label fx:id="telegramUsername" styleClass="cell_small_label" />
+          <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true" maxWidth="1400" maxHeight="50"/>
+          <Label fx:id="telegramUsername" styleClass="cell_small_label" minWidth="250"/>
         </HBox>
       </HBox>
       <FlowPane fx:id="roles" />

--- a/src/test/java/seedu/address/model/event/EventTest.java
+++ b/src/test/java/seedu/address/model/event/EventTest.java
@@ -234,6 +234,7 @@ public class EventTest {
     @Test
     public void isValidEvent_invalidInput_false() {
         assertFalse(Event.isValidEvent(""));
+        assertFalse(Event.isValidEvent("The longest event name in the history of mankind ever forever")); // 61 > 60
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -27,6 +27,8 @@ public class AddressTest {
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
         assertFalse(Address.isValidAddress(" ")); // spaces only
+        assertFalse(Address.isValidAddress("24 Johnny Cena Street Earth Milky Way Galaxy; Emperor's Angels"
+                + " Ultramarine Chapter, 172 Avenue Bolter Tower, Cadia Stands")); // 121 character long > 120 allowed
 
         // valid addresses
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -51,13 +51,15 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
+        assertFalse(Email.isValidEmail("1234567890@111111111.222222222.333333333.444444444.555555555."
+                + "666666666.777777777.888888888.999999999.000000000.1111111111")); // 121 character long > 120 allowed
 
         // valid email
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
+        assertTrue(Email.isValidEmail("a@bc")); // minimal domain labels
         assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
         assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
@@ -68,10 +70,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@email.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@email.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -83,6 +85,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@email.com")));
     }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -30,7 +30,7 @@ public class NameTest {
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
         assertFalse(Name.isValidName("Lord Chapter Master Grandmaster Calgar Anduro Jackson Ultramarine"
-        + " David Roger Jackson Ray Jr 2nd dean"));  // 121 characters > 100 allowed
+                + " David Roger Jackson Ray Jr 2nd dean")); // 121 characters > 100 allowed
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,6 +29,8 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("Lord Chapter Master Grandmaster Calgar Anduro Jackson Ultramarine"
+        + " David Roger Jackson Ray Jr 2nd dean"));  // 121 characters > 100 allowed
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only


### PR DESCRIPTION
- Fixes #244 

Event names are restricted to 60 characters
Names are restricted to 100 characters
address and emails are restricted to 120 characters

![image](https://github.com/user-attachments/assets/77508409-505c-448f-bf82-4d8be0b2d94f)
