### PR TITLE
Fix Phone Number Bug

### DIFF
--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -10,9 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Phone {
 
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long.";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String MESSAGE_CONSTRAINTS = "Phone numbers should only contain numbers, "
+            + "and it should be between 3 and 17 digits long (both inclusive).";
+    public static final String VALIDATION_REGEX = "\\d{3,17}";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -32,7 +32,7 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
         assertFalse(Phone.isValidPhone("124293842033123456")); // more than 17 numbers
-        assertFalse(Phone.isValidPhone("124293842 033123456")); // more than 17 numbers, split
+        assertFalse(Phone.isValidPhone("124293842 033123456")); // more than 17 numbers, split up
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -31,11 +31,13 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("124293842033123456")); // more than 17 numbers
+        assertFalse(Phone.isValidPhone("124293842 033123456")); // more than 17 numbers, split
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("93121534")); // exactly 8 numbers, standard for Singapore phone numbers
+        assertTrue(Phone.isValidPhone("12429384203312345")); // exactly 17 numbers
     }
 
     @Test


### PR DESCRIPTION
## Overview

Previously, we only set a lower bound to the length of the phone number of a Person. We enforced a minimum length of 3. However, there was no upper bound. This PR address the issue.

## Issues Fixed

Closes #249 