### PR TITLE
Alter message

### DIFF
--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Address {
 
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, "
-            + "but should not be blank, and should be less than 120 characters.";
+            + "but should not be blank, and should be 120 characters or less.";
 
     /*
      * The first character of the address must not be a whitespace,


### PR DESCRIPTION
## Overview

Currently, if an incorrect address (wrong format) is entered into the system, the user is informed that addresses must be less than 120 characters long.

The corrected message should be `120 characters or less`, since we counted 120 characters as a valid input!

## Issues fixed

Fixes #316