### PR TITLE
Widen remove error messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -25,8 +25,8 @@ public class RemovePersonFromEventCommand extends Command {
 
     public static final String COMMAND_WORD = "remove";
     public static final String MESSAGE_SUCCESS = "Contact %1$s removed from event %2$s";
-    public static final String MESSAGE_PERSON_NOT_FOUND = "Contact not found in event";
-    public static final String MESSAGE_EVENT_NOT_FOUND = "Event not found";
+    public static final String MESSAGE_PERSON_NOT_FOUND = "Contact not found in event \nOr contact index is invalid";
+    public static final String MESSAGE_EVENT_NOT_FOUND = "Event not found" + "\nOr event index is invalid";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + " ei/EVENT_INDEX ci/CONTACT_INDEX : Removes a contact from "


### PR DESCRIPTION
Changes the error message to better represent cases of invalid indices. Seems to be allowed according to the forum reply.

Closes #307 