### PR TITLE
Fix event card display numbers and event specific roles

### DIFF
--- a/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/event/commands/RemovePersonFromEventCommand.java
@@ -89,10 +89,10 @@ public class RemovePersonFromEventCommand extends Command {
     private static void updateContactsIfInEventViewToShowRemovedContact(Model model, EventManager eventManager,
                                                                         Event event) {
         // check the last shown list if it is event
-        model.setIsFindEvent(false);
         Predicate<Person> lastPred = model.getLastPredicate();
         if (lastPred instanceof PersonInEventPredicate) {
             if (((PersonInEventPredicate) lastPred).getEvent().equals(event)) {
+                model.setIsFindEvent(false);
                 //create a new predicate for changed event
                 model.updateFilteredPersonList(eventManager.getPersonInEventPredicate(event));
                 FindEventCommand.updateContactsUiWithEventSpecificRoles(model, event);

--- a/src/test/java/seedu/address/logic/commands/contact/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/commands/DeleteCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalEvents.TECH_CONFERENCE;
 import static seedu.address.testutil.TypicalEvents.getTypicalEventManager;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
@@ -15,10 +16,13 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonInEventPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -65,6 +69,20 @@ public class DeleteCommandTest {
         showNoPerson(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexEventView_success() throws CommandException {
+        model.updateFilteredPersonList(new PersonInEventPredicate(TECH_CONFERENCE));
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete));
+
+        assertEquals(new CommandResult(String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                Messages.format(personToDelete))), deleteCommand.execute(model, model.getEventManager()));
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/event/commands/AddPersonToEventCommandTest.java
@@ -27,6 +27,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.event.Event;
 import seedu.address.model.event.EventManager;
+import seedu.address.model.person.PersonInEventPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.EventBuilder;
 
@@ -101,6 +102,23 @@ public class AddPersonToEventCommandTest {
         vendors.add(Index.fromZeroBased(2));
         sponsors.add(Index.fromZeroBased(1));
 
+        AddPersonToEventCommand addPersonToEventCommand = new
+                AddPersonToEventCommand(Index.fromZeroBased(2),
+                attendees, volunteers, vendors, sponsors);
+        Event expectedEvent = TEST_EVENT;
+        addPersonToEventCommand.execute(this.model, this.eventManager);
+        Event actualEvent = this.eventManager.getEventList().get(2);
+        assertEquals(expectedEvent, actualEvent);
+    }
+
+    @Test
+    public void execute_correctInputsAndInEventView_contactsAddedToEventSuccessfully() throws CommandException {
+        attendees.add(Index.fromZeroBased(0));
+        volunteers.add(Index.fromZeroBased(3));
+        vendors.add(Index.fromZeroBased(2));
+        sponsors.add(Index.fromZeroBased(1));
+
+        this.model.updateFilteredPersonList(new PersonInEventPredicate(TEST_EVENT));
         AddPersonToEventCommand addPersonToEventCommand = new
                 AddPersonToEventCommand(Index.fromZeroBased(2),
                 attendees, volunteers, vendors, sponsors);


### PR DESCRIPTION
There are instances where deleting a contact while viewing a list of contacts returned from find-event will cause the contacts' non-event specific roles to pop out, which is not intended. This PR aims to fix that by checking if the user had previous entered a find-event command and if so, update the list of contacts with event-specific roles only.

Another bug occurs when adding a contact to an event when the contact is already inside the event, but adding to another role after executing find-event, as the UI does not update to reflect that the contact has an additional event-specific role. This PR fixes that by creating a new list of contacts in the event with their updated roles and displaying these contacts.

Additionally, while in find-event of event A, if a user executes remove contact of event B, the contacts' non-event specific roles will pop out again, thus this PR fixes that as well.

Lastly, there are cases where the event card does not show updated count due to add persons to event command not updating the event card at the right place. If there is a contact that cannot be added to the event, an exception is thrown to inform the user but the previous contacts that can be added are already added, and the code never reaches the line where the event card is updated. This is fixed by calling the event card update code after every add operation.