### PR TITLE
Change contact of initial events

### DIFF
--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -177,7 +177,7 @@ public class SampleDataUtil {
         return new Event[] {
             new Event("NUS Student Life Fair 2024",
                     getPersonSet(samplePersons[20]),
-                    getPersonSet(samplePersons[0]),
+                    getPersonSet(samplePersons[3]),
                     getPersonSet(samplePersons[5]),
                     getPersonSet(samplePersons[22])
             ),


### PR DESCRIPTION
Seems like there is a bug in the contact of the initial event where Agency for Science Technology and Really Cool Stuff A STAR is only a sponsor but exist in NUS Student Life Fair 2024 as vendor. 

This PR changes the vendor in NUS Student Life Fair 2024 to Deliveroo Delight instead.